### PR TITLE
fix: ensure tool result content is always array format

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -689,13 +689,27 @@ function sliceLastTurn(
   const TOOL_MAX = 6000;
   kept = kept.map((msg: any) => {
     if (msg.role !== "tool" && msg.role !== "toolResult") return msg;
-    const text = typeof msg.content === "string"
-      ? msg.content
-      : JSON.stringify(msg.content ?? "");
-    if (text.length <= TOOL_MAX) return msg;
+    // Extract text from both string and array content formats
+    let text: string;
+    if (typeof msg.content === "string") {
+      text = msg.content;
+    } else if (Array.isArray(msg.content)) {
+      text = msg.content
+        .filter((b: any) => b && typeof b === "object" && typeof b.text === "string")
+        .map((b: any) => b.text)
+        .join("\n");
+    } else {
+      text = JSON.stringify(msg.content ?? "");
+    }
+    if (text.length <= TOOL_MAX) {
+      // Ensure content is always in array format for OpenClaw core compatibility
+      if (Array.isArray(msg.content)) return msg;
+      return { ...msg, content: [{ type: "text", text }] };
+    }
     const head = Math.floor(TOOL_MAX * 0.6);
     const tail = Math.floor(TOOL_MAX * 0.3);
-    return { ...msg, content: text.slice(0, head) + `\n...[truncated ${text.length - head - tail} chars]...\n` + text.slice(-tail) };
+    const truncated = text.slice(0, head) + `\n...[truncated ${text.length - head - tail} chars]...\n` + text.slice(-tail);
+    return { ...msg, content: [{ type: "text", text: truncated }] };
   });
 
   let tokens = 0;


### PR DESCRIPTION
## Problem

OpenClaw core expects `toolMsg.content` to be an array of `{type, text}` objects. When the context compactor encounters a short tool result (≤6000 chars), it returns the original message unchanged. If `msg.content` is a raw string, the core code crashes:

```
toolMsg.content.filter is not a function
```

This causes the **entire agent session to crash silently**, losing all context and memory. The agent appears to "amnesia" after 2-3 rounds of conversation.

## Root Cause

In `contextCompactor`, the short message path:
```typescript
const text = typeof msg.content === "string" ? msg.content : JSON.stringify(...);
if (text.length <= TOOL_MAX) return msg;  // ← returns string content unchanged
```

The truncated path also returns a plain string:
```typescript
return { ...msg, content: "truncated string" };  // ← wrong format
```

## Fix

1. **Extract text from both string and array content formats** — properly handles `{type: "text", text}` array elements
2. **Short messages**: ensure `content` is always `[{type: "text", text}]` array format
3. **Truncated messages**: return array format instead of raw string
4. **Avoid JSON.stringify on arrays** — prevents double-encoding of structured content

## Testing

Tested locally with graph-memory plugin loaded. Agent no longer crashes when context compactor processes tool results. Memory and conversation continuity preserved across multiple rounds.