### PR TITLE
Fixed #48 and #57

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,7 @@ sqlite3 ~/.openclaw/graph-memory.db "SELECT id, summary FROM gm_communities;"
 |------|-------------|
 | `gm_search` | Search the knowledge graph for relevant skills, events, and solutions |
 | `gm_record` | Manually record knowledge to the graph |
+| `gm_update` | Update an existing node's description and/or content by exact name (throws if not found) |
 | `gm_stats` | View graph statistics: nodes, edges, communities, PageRank top nodes |
 | `gm_maintain` | Manually trigger graph maintenance: dedup → PageRank → community detection + summaries |
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -335,6 +335,7 @@ sqlite3 ~/.openclaw/graph-memory.db "SELECT id, summary FROM gm_communities;"
 |------|------|
 | `gm_search` | 搜索图谱中的相关经验、技能和解决方案 |
 | `gm_record` | 手动记录经验到图谱 |
+| `gm_update` | 按精确节点名称更新已有节点的描述和/或内容（不存在则报错） |
 | `gm_stats` | 查看图谱统计：节点数、边数、社区数、PageRank Top 节点 |
 | `gm_maintain` | 手动触发图维护：去重 → PageRank → 社区检测 + 摘要生成 |
 

--- a/index.ts
+++ b/index.ts
@@ -15,7 +15,7 @@ import { getDb } from "./src/store/db.ts";
 import {
   saveMessage, getUnextracted,
   markExtracted,
-  upsertNode, upsertEdge, findByName,
+  upsertNode, upsertEdge, findByName, updateNode,
   getBySession, edgesFrom, edgesTo,
   deprecate, getStats,
 } from "./src/store/store.ts";
@@ -44,10 +44,6 @@ function readProviderModel(apiConfig: unknown): { provider: string; model: strin
     }
   }
 
-  if (!raw) {
-    raw = "anthropic/claude-haiku-4-5-20251001";
-  }
-
   if (raw.includes("/")) {
     const [provider, ...rest] = raw.split("/");
     const model = rest.join("/").trim();
@@ -56,8 +52,11 @@ function readProviderModel(apiConfig: unknown): { provider: string; model: strin
     }
   }
 
-  const provider = "anthropic";
-  return { provider, model: raw };
+  if (raw) {
+    return { provider: "anthropic", model: raw };
+  }
+
+  return { provider: "", model: "" };
 }
 
 // ─── 清洗 OpenClaw metadata 包装 ─────────────────────────────
@@ -130,6 +129,14 @@ const graphMemoryPlugin = {
         : {};
     const cfg: GmConfig = { ...DEFAULT_CONFIG, ...raw };
     const { provider, model } = readProviderModel(api.config);
+
+    const effectiveModel = cfg.llm?.model ?? model;
+    if (!effectiveModel) {
+      api.logger.warn(
+        "[graph-memory] No LLM model configured. Set agents.defaults.model in openclaw.json " +
+        "or config.llm.model in graph-memory plugin config — extraction and community summaries will fail.",
+      );
+    }
 
     // ── 初始化核心模块 ──────────────────────────────────────
     const db = getDb(cfg.dbPath);
@@ -675,6 +682,62 @@ const graphMemoryPlugin = {
     );
 
     api.registerTool(
+      (ctx: any) => ({
+        name: "gm_update",
+        label: "Update Graph Memory Node",
+        description:
+          "更新知识图谱中已存在的节点。必须提供精确的节点名称（不存在会报错）。用于 refine 已有经验的描述或内容，避免重复创建节点。",
+        parameters: Type.Object({
+          name: Type.String({ description: "要更新的节点名称（必须精确匹配已有节点；名称会被标准化：全小写、空格/下划线转连字符）" }),
+          description: Type.Optional(
+            Type.String({ description: "新的一句话说明（one-line summary）。不传则保留原值" }),
+          ),
+          content: Type.Optional(
+            Type.String({ description: "新的知识内容（纯文本）。不传则保留原值" }),
+          ),
+        }),
+        async execute(
+          _toolCallId: string,
+          p: { name: string; description?: string; content?: string },
+        ) {
+          if (p.description === undefined && p.content === undefined) {
+            throw new Error(
+              "[graph-memory] gm_update 至少需要提供 description 或 content 中的一个",
+            );
+          }
+          const updated = updateNode(db, p.name, {
+            description: p.description,
+            content: p.content,
+          });
+          if (!updated) {
+            throw new Error(
+              `[graph-memory] 未找到名称为 "${p.name}" 的节点。` +
+              `请检查节点名称是否精确（名称标准化规则：全小写、空格/下划线转连字符、移除非字母数字字符），` +
+              `或使用 gm_record 创建新节点，也可用 gm_search 搜索已有节点。`,
+            );
+          }
+          recaller.syncEmbed(updated).catch(() => {});
+          const changes: string[] = [];
+          if (p.description !== undefined) changes.push(`description="${updated.description}"`);
+          if (p.content !== undefined) changes.push(`content (${updated.content.length} chars)`);
+          return {
+            content: [{
+              type: "text",
+              text: `已更新：${updated.name} (${updated.type})\n变更：${changes.join("，")}`,
+            }],
+            details: {
+              name: updated.name,
+              type: updated.type,
+              description: updated.description,
+              contentLength: updated.content.length,
+            },
+          };
+        },
+      }),
+      { name: "gm_update" },
+    );
+
+    api.registerTool(
       (_ctx: any) => ({
         name: "gm_stats",
         label: "Graph Memory Stats",
@@ -738,7 +801,7 @@ const graphMemoryPlugin = {
     );
 
     api.logger.info(
-      `[graph-memory] ready | db=${cfg.dbPath} | provider=${provider} | model=${model}`,
+      `[graph-memory] ready | db=${cfg.dbPath} | provider=${provider} | model=${effectiveModel || "(none)"}`,
     );
   },
 };

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -91,6 +91,22 @@ export function upsertNode(
   return { node: findByName(db, name)!, isNew: true };
 }
 
+/** 按 name 精确更新 description / content；找不到返回 null（调用方决定报错语义） */
+export function updateNode(
+  db: DatabaseSyncInstance,
+  name: string,
+  patch: { description?: string; content?: string },
+): GmNode | null {
+  const ex = findByName(db, name);
+  if (!ex) return null;
+  const now = Date.now();
+  const description = patch.description ?? ex.description;
+  const content = patch.content ?? ex.content;
+  db.prepare("UPDATE gm_nodes SET description=?, content=?, updated_at=? WHERE id=?")
+    .run(description, content, now, ex.id);
+  return { ...ex, description, content, updatedAt: now };
+}
+
 export function deprecate(db: DatabaseSyncInstance, nodeId: string): void {
   db.prepare("UPDATE gm_nodes SET status='deprecated', updated_at=? WHERE id=?")
     .run(Date.now(), nodeId);

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -9,7 +9,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { DatabaseSync, type DatabaseSyncInstance } from "@photostructure/sqlite";
 import { createTestDb, insertNode, insertEdge } from "./helpers.ts";
 import {
-  findByName, findById, upsertNode, upsertEdge, deprecate,
+  findByName, findById, upsertNode, upsertEdge, updateNode, deprecate,
   mergeNodes, edgesFrom, edgesTo, allActiveNodes, allEdges,
   searchNodes, topNodes, graphWalk, getBySession,
   saveMessage, getMessages, getUnextracted, markExtracted,
@@ -82,6 +82,71 @@ describe("node CRUD", () => {
 
   it("findByName 找不到返回 null", () => {
     expect(findByName(db, "not-exist")).toBeNull();
+  });
+
+  it("updateNode 找不到节点返回 null", () => {
+    expect(updateNode(db, "ghost", { description: "x" })).toBeNull();
+    expect(updateNode(db, "ghost", { content: "y" })).toBeNull();
+  });
+
+  it("updateNode 只更新 description，保留 content", () => {
+    const { node } = upsertNode(db, {
+      type: "SKILL", name: "docker-build",
+      description: "旧描述", content: "原内容保持不变",
+    }, "s1");
+
+    const updated = updateNode(db, "docker-build", { description: "新描述" });
+    expect(updated).not.toBeNull();
+    expect(updated!.description).toBe("新描述");
+    expect(updated!.content).toBe("原内容保持不变");
+  });
+
+  it("updateNode 只更新 content，保留 description", () => {
+    upsertNode(db, {
+      type: "SKILL", name: "docker-run",
+      description: "描述不动", content: "旧内容",
+    }, "s1");
+
+    const updated = updateNode(db, "docker-run", { content: "全新内容" });
+    expect(updated).not.toBeNull();
+    expect(updated!.description).toBe("描述不动");
+    expect(updated!.content).toBe("全新内容");
+  });
+
+  it("updateNode 同时更新 description 和 content", () => {
+    upsertNode(db, {
+      type: "EVENT", name: "oom-crash",
+      description: "旧", content: "旧内容",
+    }, "s1");
+
+    const updated = updateNode(db, "oom-crash", {
+      description: "新描述", content: "新内容",
+    });
+    expect(updated!.description).toBe("新描述");
+    expect(updated!.content).toBe("新内容");
+  });
+
+  it("updateNode 保留 type/name/status/validatedCount，刷新 updated_at", () => {
+    const { node } = upsertNode(db, {
+      type: "SKILL", name: "preserve-me",
+      description: "d1", content: "c1",
+    }, "s1");
+    // 第二次 upsert 把 validated_count 提到 2
+    upsertNode(db, {
+      type: "SKILL", name: "preserve-me",
+      description: "d1", content: "c1",
+    }, "s2");
+    const before = findByName(db, "preserve-me")!;
+    expect(before.validatedCount).toBe(2);
+
+    const updated = updateNode(db, "preserve-me", { content: "refined" });
+    expect(updated!.type).toBe("SKILL");
+    expect(updated!.name).toBe("preserve-me");
+    expect(updated!.status).toBe("active");
+    expect(updated!.validatedCount).toBe(2);
+    expect(updated!.sourceSessions).toEqual(["s1", "s2"]);
+    expect(updated!.content).toBe("refined");
+    expect(updated!.updatedAt).toBeGreaterThanOrEqual(before.updatedAt);
   });
 });
 


### PR DESCRIPTION
完成了https://github.com/adoresever/graph-memory/issues/57 和 https://github.com/adoresever/graph-memory/issues/48

添加了图谱修改工具和硬编码的claude模型名称