### PR TITLE
fix(embedding): correct MiniMax (MiniMax CodePlan) adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The embedding module now uses raw `fetch` instead of the `openai` SDK, making it
 
 - OpenAI, Azure OpenAI
 - Alibaba DashScope (`text-embedding-v4`)
-- MiniMax (`embo-01`)
+- MiniMax (`embo-01`, 1536d — uses `texts` + `type` body format, not OpenAI `input`)
 - Ollama, llama.cpp, vLLM (local models)
 - Any endpoint that implements `POST /embeddings`
 
@@ -278,7 +278,7 @@ If `config.llm` is not set, graph-memory falls back to the `ANTHROPIC_API_KEY` e
 |----------|---------|-------|------------|
 | OpenAI | `https://api.openai.com/v1` | `text-embedding-3-small` | 512 |
 | Alibaba DashScope | `https://dashscope.aliyuncs.com/compatible-mode/v1` | `text-embedding-v4` | 1024 |
-| MiniMax | `https://api.minimax.chat/v1` | `embo-01` | 1024 |
+| MiniMax (MiniMax CodePlan) | `https://api.minimaxi.com/v1` | `embo-01` | 1536 |
 | Ollama | `http://localhost:11434/v1` | `nomic-embed-text` | 768 |
 | llama.cpp | `http://127.0.0.1:8080/v1` | your model name | varies |
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -61,7 +61,7 @@ Embedding 模块改用原生 `fetch` 替代 `openai` SDK，开箱即用兼容**�
 
 - OpenAI、Azure OpenAI
 - 阿里云 DashScope（`text-embedding-v4`）
-- MiniMax（`embo-01`）
+- MiniMax（`embo-01`，1536 维 —— 使用 `texts` + `type` 请求体，不是 OpenAI 的 `input`）
 - Ollama、llama.cpp、vLLM（本地模型）
 - 任何实现了 `POST /embeddings` 的端点
 
@@ -280,7 +280,7 @@ pnpm openclaw plugins install .
 |--------|---------|------|------------|
 | OpenAI | `https://api.openai.com/v1` | `text-embedding-3-small` | 512 |
 | 阿里云 DashScope | `https://dashscope.aliyuncs.com/compatible-mode/v1` | `text-embedding-v4` | 1024 |
-| MiniMax | `https://api.minimax.chat/v1` | `embo-01` | 1024 |
+| MiniMax (MiniMax CodePlan) | `https://api.minimaxi.com/v1` | `embo-01` | 1536 |
 | Ollama | `http://localhost:11434/v1` | `nomic-embed-text` | 768 |
 | llama.cpp | `http://127.0.0.1:8080/v1` | 你的模型名 | 视模型而定 |
 

--- a/src/engine/embed.ts
+++ b/src/engine/embed.ts
@@ -11,14 +11,21 @@
  * 可选模块：配了 embedding.apiKey 才启用，否则返回 null → 降级 FTS5
  *
  * 使用 fetch 直接调 OpenAI 兼容 /embeddings 接口（不依赖 openai SDK），
- * 兼容 OpenAI、阿里云 DashScope、MiniMax、Jina、Ollama、llama.cpp 等。
+ * 兼容 OpenAI、阿里云 DashScope、MiniMax(MiniMax CodePlan)、Jina、Ollama、llama.cpp 等。
+ *
+ * MiniMax(MiniMax) 是特例：
+ *   - 端点走 anthropic 协议但 embeddings 用 OpenAI 风格变体
+ *   - 请求体用 `texts: [...]` + `type: "db" | "query"`（不是 OpenAI 的 `input`）
+ *   - 响应字段是 `data[0].vector`（不是 `data[0].embedding`）
+ *   - 维度固定 1536，不接受 `dimensions` 参数
  *
  * 内置：429/5xx 重试 3 次 + 10s 超时
  */
 
 import type { EmbeddingConfig } from "../types.ts";
 
-export type EmbedFn = (text: string) => Promise<number[]>;
+export type EmbedMode = "db" | "query";
+export type EmbedFn = (text: string, mode?: EmbedMode) => Promise<number[]>;
 
 // ─── 带重试+超时的 fetch ─────────────────────────────────────
 
@@ -42,6 +49,16 @@ async function fetchRetry(url: string, init: RequestInit, retries = 3, timeoutMs
   throw new Error("[graph-memory] embed fetch failed after retries");
 }
 
+// ─── Provider 识别 ───────────────────────────────────────────
+
+/**
+ * 识别 MiniMax(MiniMax CodePlan) 端点。
+ * 海外 minimax.io 国内打不开，所以 baseURL 主要是 api.minimaxi.com / minimax.chat。
+ */
+function isMinimax(baseURL: string): boolean {
+  return /minimaxi\.com|minimax\.chat|minimax\.io/i.test(baseURL);
+}
+
 // ─── EmbedFn 工厂 ───────────────────────────────────────────
 
 export async function createEmbedFn(cfg: EmbeddingConfig | undefined): Promise<EmbedFn | null> {
@@ -50,21 +67,34 @@ export async function createEmbedFn(cfg: EmbeddingConfig | undefined): Promise<E
   const baseURL    = (cfg.baseURL ?? "https://api.openai.com/v1").replace(/\/+$/, "");
   const model      = cfg.model ?? "text-embedding-3-small";
   const dimensions = cfg.dimensions && cfg.dimensions > 0 ? cfg.dimensions : undefined;
+  const minimax    = isMinimax(baseURL);
 
-  function buildBody(input: string): Record<string, unknown> {
+  /**
+   * 构造请求 body。MiniMax 走 texts+type 分支，其他 OpenAI 兼容端点维持原行为。
+   * type: db=入库, query=查询（MiniMax 内部用不同模型）
+   */
+  function buildBody(input: string, mode: EmbedMode): Record<string, unknown> {
+    if (minimax) {
+      return {
+        model,
+        texts: [input],
+        type: mode, // "db" | "query"
+        // MiniMax 不接受 dimensions
+      };
+    }
     const body: Record<string, unknown> = { model, input };
     if (dimensions) body.dimensions = dimensions;
     return body;
   }
 
-  async function callEmbedding(input: string): Promise<number[]> {
+  async function callEmbedding(input: string, mode: EmbedMode): Promise<number[]> {
     const res = await fetchRetry(`${baseURL}/embeddings`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
         "Authorization": `Bearer ${cfg!.apiKey}`,
       },
-      body: JSON.stringify(buildBody(input)),
+      body: JSON.stringify(buildBody(input, mode)),
     });
 
     if (!res.ok) {
@@ -73,7 +103,9 @@ export async function createEmbedFn(cfg: EmbeddingConfig | undefined): Promise<E
     }
 
     const data = await res.json() as any;
-    const embedding = data?.data?.[0]?.embedding;
+    // MiniMax: data[0].vector；OpenAI 兼容: data[0].embedding
+    const item = data?.data?.[0];
+    const embedding: number[] | undefined = minimax ? item?.vector : item?.embedding;
     if (!Array.isArray(embedding) || !embedding.length) {
       throw new Error("[graph-memory] Embedding API returned empty embedding");
     }
@@ -82,11 +114,11 @@ export async function createEmbedFn(cfg: EmbeddingConfig | undefined): Promise<E
 
   // ── 验证连通性 ────────────────────────────────────────────
   try {
-    const probe = await callEmbedding("ping");
+    const probe = await callEmbedding("ping", "query");
     if (!probe.length) return null;
 
-    return async (text: string): Promise<number[]> => {
-      return callEmbedding(text.slice(0, 8000));
+    return async (text: string, mode: EmbedMode = "db"): Promise<number[]> => {
+      return callEmbedding(text.slice(0, 8000), mode);
     };
   } catch (err) {
     console.error(`[graph-memory] embedding probe failed:`, err);

--- a/src/graph/community.ts
+++ b/src/graph/community.ts
@@ -230,7 +230,7 @@ export async function summarizeCommunities(
       if (embedFn) {
         try {
           const embedText = `${cleaned}\n${members.map((m: any) => m.name).join(", ")}`;
-          embedding = await embedFn(embedText);
+          embedding = await embedFn(embedText, "db");
         } catch {
           if (process.env.GM_DEBUG) {
             console.log(`  [DEBUG] community embedding failed for ${communityId}`);

--- a/src/recaller/recall.ts
+++ b/src/recaller/recall.ts
@@ -62,7 +62,7 @@ export class Recaller {
 
     if (this.embed) {
       try {
-        const vec = await this.embed(query);
+        const vec = await this.embed(query, "query");
         const scored = vectorSearchWithScore(this.db, vec, Math.ceil(limit / 2));
         seeds = scored.map(s => s.node);
 
@@ -137,7 +137,7 @@ export class Recaller {
     // 优先用社区向量搜索
     if (this.embed) {
       try {
-        const vec = await this.embed(query);
+        const vec = await this.embed(query, "query");
         const scoredCommunities = communityVectorSearch(this.db, vec);
 
         if (scoredCommunities.length > 0) {
@@ -236,7 +236,7 @@ export class Recaller {
     if (getVectorHash(this.db, node.id) === hash) return;
     try {
       const text = `${node.name}: ${node.description}\n${node.content.slice(0, 500)}`;
-      const vec = await this.embed(text);
+      const vec = await this.embed(text, "db");
       if (vec.length) saveVector(this.db, node.id, node.content, vec);
     } catch { /* 不影响主流程 */ }
   }


### PR DESCRIPTION
## Summary

Fix the embedding adapter so that users running the **MiniMax CodePlan** OAuth service (the platform referred to as "MiniMax" in the README — the alias predates this PR and is left intact for backward compatibility) can actually use it.

## What's wrong today

- README documents `baseURL=https://api.minimax.chat/v1` and `dimensions=1024` for MiniMax. The reachable endpoint is `https://api.minimaxi.com/v1` and `embo-01` returns **1536-d** vectors.
- Even with the right URL, the adapter sends `{"input": "..."}` and reads `data[0].embedding`. MiniMax's `/embeddings` expects `{"texts": [...], "type": "db"|"query"}` and returns `data[0].vector`. So every call fails with `missing required parameter expr_path=texts` or returns an empty embedding.

## What this PR changes

- `src/engine/embed.ts`
  - Adds `isMinimax(baseURL)` detection (matches `minimaxi.com`, `minimax.chat`, `minimax.io`).
  - When detected, sends `{model, texts:[input], type}` instead of `{model, input}`, and omits `dimensions` (MiniMax rejects it).
  - Reads `data[0].vector` for MiniMax, `data[0].embedding` for everything else.
  - Extends `EmbedFn` to `(text: string, mode?: "db" | "query") => Promise<number[]>`. MiniMax routes the two modes through different retrieval models, so callers need to be explicit.
- `src/recaller/recall.ts` — `recallPrecise` / `recallGeneralized` pass `"query"`, `syncEmbed` passes `"db"`.
- `src/graph/community.ts` — community summarization passes `"db"`.
- `README.md` / `README_CN.md`
  - Provider table row corrected: `baseURL=api.minimaxi.com`, `dimensions=1536`, label clarified as `MiniMax (MiniMax CodePlan)`.
  - Universal-embedding bullets now note the MiniMax format exception.

## Backward compatibility

- Other providers (OpenAI, DashScope, Jina, Ollama, llama.cpp, etc.) are **unchanged**: same request body shape, same `data[0].embedding` parsing, same `dimensions` handling. Their existing embeddings keep working.
- The `mode` argument on `EmbedFn` is optional and defaults to `"db"`, so any external code that constructs a custom `EmbedFn` keeps compiling.

## Verification

- Local: TS compiles, the four `EmbedFn` call sites all pass the new mode (verified by grepping for `this.embed(` / `embedFn(`).
- Runtime: I run graph-memory against the actual MiniMax CodePlan service (oauth-cn endpoint, `api.minimaxi.com`). Before the patch the embed probe fails with `missing required parameter expr_path=texts`; after the patch recall reports `vector search ready` and 1536-d vectors are stored and used for vector search + community summaries.

## Notes for the maintainer

- The "MiniMax" string in the existing README/code was a pre-existing alias. I kept it everywhere for diff minimality, but expanded the README label to `MiniMax (MiniMax CodePlan)` so the official product name is now discoverable from the docs. Happy to rename wholesale in a follow-up if you'd prefer.
- Test suite wasn't run inside this PR — WSL/3 GB memory kills `vitest run`. The change is small (one new function plus a branch in `buildBody`) and the four call-site updates are mechanical, but I can add a unit test for `createEmbedFn` if you want.