### PR TITLE
fix: escape {{template variables}} in assemble to prevent DSH prompt interpolation errors

### DIFF
--- a/src/format/assemble.ts
+++ b/src/format/assemble.ts
@@ -204,5 +204,13 @@ export function assembleContext(
 }
 
 function escapeXml(s: string): string {
-  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    // 防止 DSH prompt template 系统把 {{variable}} 当成需要解析的变量
+    // 只转义成对的 {{ }}，保留单个 { } 不动（兼容 CSS/JSON 等内容）
+    .replace(/\{\{/g, "&#123;&#123;")
+    .replace(/\}\}/g, "&#125;&#125;");
 }


### PR DESCRIPTION
## Problem

Node content may contain `{{unsubscribe_url}}` or similar template syntax (e.g. from Buttondown email templates). When graph-memory recalls these nodes and injects them into the `graph-memory:recall` context, DSH's prompt template system scans for `{{variable}}` patterns and throws:

```
unknown prompt variable "{{unsubscribe_url}}" in context "graph-memory:recall"
```

This affects any node whose content happens to contain double-curly-brace syntax.

## Fix

Escape `{{` and `}}` as HTML entities (`&#123;&#123;` / `&#125;&#125;`) in the `escapeXml` function in `assemble.ts`. This prevents DSH's interpolation from interpreting them as template variables.

- Only **paired** braces (`{{` / `}}`) are escaped — single `{` or `}` are preserved for CSS/JSON compatibility
- All content passing through `escapeXml` (node body, description, edge conditions, episodic messages) is protected

## Example

Before: `{{unsubscribe_url}}` → DSH tries to resolve → throws error  
After: `&#123;&#123;unsubscribe_url&#125;&#125;` → passes through literally ✅