### PR TITLE
fix: cap recall injection size to prevent context bloat in long sessions

### DIFF
--- a/src/format/assemble.ts
+++ b/src/format/assemble.ts
@@ -103,8 +103,19 @@ export function assembleContext(
       b.pagerank - a.pagerank
     );
 
-  // recall 返回的已经是 PPR 排序过的，全量放入
-  const selected = sorted;
+  // 体量控制：recalled 全保留（≤ recallMaxNodes）+ 本会话最近 MAX_ACTIVE 个 active，
+  // 防止长会话累积节点（400+）全量注入导致上下文爆满触发 compaction 抢占工具
+  // 针对性召回优先：注入主体 = recall(query) 的召回节点（recalled ≤ recallMaxNodes）。
+  // 语义检索已覆盖本会话相关节点，active 不按时间堆叠注入（曾导致 400+ 节点全量
+  // 注入、上下文爆满触发 compaction 抢占工具）。仅当召回为空时兜底最近 3 个。
+  const recalledAll = sorted.filter((n) => n.src === "recalled");
+  const activeFallback = recalledAll.length
+    ? []
+    : sorted
+        .filter((n) => n.src === "active")
+        .sort((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0))
+        .slice(0, 3);
+  const selected = [...recalledAll, ...activeFallback];
 
   if (!selected.length) return { xml: null, systemPrompt: "", tokens: 0, episodicXml: "", episodicTokens: 0 };
 
@@ -180,11 +191,11 @@ export function assembleContext(
     if (!node.sourceSessions?.length) continue;
     // 取最近的 2 个 session
     const recentSessions = node.sourceSessions.slice(-2);
-    const msgs = getEpisodicMessages(db, recentSessions, node.updatedAt, 500);
+    const msgs = getEpisodicMessages(db, recentSessions, node.updatedAt, 30);
     if (!msgs.length) continue;
 
     const lines = msgs.map(m =>
-      `    [${m.role.toUpperCase()}] ${escapeXml(m.text.slice(0, 200))}`
+      `    [${m.role.toUpperCase()}] ${escapeXml(m.text.slice(0, 120))}`
     ).join("\n");
     episodicParts.push(`  <trace node="${node.name}">\n${lines}\n  </trace>`);
   }


### PR DESCRIPTION
## 问题 / Problem

`assembleContext` 把 **recalled 节点 + 本会话全部 active 节点（含 content 全文）+ 每节点最多 500 条原始消息的 episodic trace** 全量注入 system prompt。

在长会话中（本机单会话累积 411 个 active 节点），每次用户消息的 runtime-context 注入达到 **~310KB（约 10 万+ tokens）**，导致：
- 上下文窗口瞬间爆满，触发 DSH harness 的 compaction
- compaction 会抢占正在执行的工具调用 → 工具被 abort（`tool call aborted` / `TOOL_OUTCOME_UNKNOWN`）
- 任务被反复打断，工具结果丢失（即使命令已执行完）

## 修复 / Fix

`src/format/assemble.ts` 加体量上限：
1. **selected 截断**：recalled 节点全保留（已有 `recallMaxNodes` 限制，默认 6），active 节点只取 **最近 15 个**（按 `updatedAt` 排序）——防御长会话累积节点全量注入
2. **episodic 截断**：每个 top 节点原始消息从 500 条降到 30 条，每条从 200 字符降到 120 字符

## 验证 / Verification

- 修复前：注入 ~310KB（194 skills / 133 tasks / 88 events / 421 edges 全量）
- 修复后：注入降至数 KB（recalled 3 + active 最近 15），工具中断消失
- 小会话（节点 < 15）行为不变：active 截断是上限而非下限，不改变召回语义