### PR TITLE
fix(dsh): isolate recalled memory from prompt templates

### DIFF
--- a/dsh.ts
+++ b/dsh.ts
@@ -25,6 +25,7 @@ import { Extractor } from "./src/extractor/extract.ts";
 import { Recaller } from "./src/recaller/recall.ts";
 import { assembleContext } from "./src/format/assemble.ts";
 import { selectDshRollingCompactionRange } from "./src/format/dsh-compaction.ts";
+import { contributePromptDataContext } from "./src/format/prompt-data.ts";
 import { createEmbedFn } from "./src/engine/embed.ts";
 import { computeGlobalPageRank, invalidateGraphCache } from "./src/graph/pagerank.ts";
 import { detectCommunities } from "./src/graph/community.ts";
@@ -544,7 +545,13 @@ export function apply(ctx: DshContext, input: Config = {}): void {
           built.xml,
           built.episodicXml,
         ].filter(Boolean).join("\n\n");
-        assembly.contexts.push({ name: "graph-memory:recall", text });
+        // Prompt contexts are template source in DSH. Contribute recalled
+        // memory as a one-pass variable value so Vue/Handlebars/CI expressions
+        // remain exact data and can never be parsed as host prompt variables.
+        contributePromptDataContext(assembly, {
+          name: "graph-memory:recall",
+          text,
+        });
       }
     } catch (error) {
       ctx.logger.warn(`[graph-memory] DSH recall failed: ${String(error)}`);

--- a/src/format/prompt-data.ts
+++ b/src/format/prompt-data.ts
@@ -1,0 +1,55 @@
+/**
+ * Safe boundary for contributing dynamic data to a one-pass prompt template.
+ *
+ * DeepSeek Harness interpolates `{{variable}}` references in context text, but
+ * deliberately does not scan substituted variable values again. Historical
+ * memory can therefore remain byte-for-byte intact when the context contains
+ * only a plugin-owned placeholder and the memory itself is stored as its value.
+ */
+
+export interface PromptDataAssembly {
+  contexts: Array<{ name: string; text: string }>;
+  variables: Record<string, string | undefined>;
+}
+
+export interface PromptDataContribution {
+  name: string;
+  text: string;
+  variableBase?: string;
+}
+
+const VARIABLE_NAME = /^[a-z][a-z0-9_]*$/;
+const DEFAULT_VARIABLE_BASE = "graph_memory_context_data";
+
+/**
+ * Append exact data through a unique prompt variable instead of placing
+ * untrusted text in the host's template source.
+ *
+ * The returned name is useful for diagnostics and tests. Existing variables
+ * are never overwritten; a deterministic suffix is allocated on collision.
+ */
+export function contributePromptDataContext(
+  assembly: PromptDataAssembly,
+  contribution: PromptDataContribution,
+): string | null {
+  if (!contribution.text) return null;
+
+  const base = contribution.variableBase ?? DEFAULT_VARIABLE_BASE;
+  if (!VARIABLE_NAME.test(base)) {
+    throw new TypeError(`invalid prompt data variable base: ${JSON.stringify(base)}`);
+  }
+
+  let variableName = base;
+  let suffix = 2;
+  while (Object.hasOwn(assembly.variables, variableName)) {
+    variableName = `${base}_${suffix}`;
+    suffix += 1;
+  }
+
+  assembly.variables[variableName] = contribution.text;
+  assembly.contexts.push({
+    name: contribution.name,
+    text: `{{${variableName}}}`,
+  });
+  return variableName;
+}

--- a/test/prompt-data.test.ts
+++ b/test/prompt-data.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import { contributePromptDataContext } from "../src/format/prompt-data.ts";
+
+describe("prompt data contribution", () => {
+  it("keeps recalled template syntax out of template source without changing data", () => {
+    const memory = [
+      "Vue {{ cardReading.positionMeaning }}",
+      "Handlebars {{{ rawHtml }}}",
+      "GitHub Actions ${{ matrix.target }}",
+      "registered-looking {{query}} is still historical data",
+    ].join("\n");
+    const assembly = {
+      contexts: [] as Array<{ name: string; text: string }>,
+      variables: { query: "current user query" } as Record<string, string | undefined>,
+    };
+
+    const variableName = contributePromptDataContext(assembly, {
+      name: "graph-memory:recall",
+      text: memory,
+    });
+
+    expect(variableName).toBe("graph_memory_context_data");
+    expect(assembly.contexts).toEqual([{
+      name: "graph-memory:recall",
+      text: "{{graph_memory_context_data}}",
+    }]);
+    expect(assembly.variables.graph_memory_context_data).toBe(memory);
+  });
+
+  it("does not overwrite another prompt provider's variable", () => {
+    const assembly = {
+      contexts: [] as Array<{ name: string; text: string }>,
+      variables: {
+        graph_memory_context_data: "owned elsewhere",
+        graph_memory_context_data_2: "also occupied",
+      } as Record<string, string | undefined>,
+    };
+
+    expect(contributePromptDataContext(assembly, {
+      name: "graph-memory:recall",
+      text: "exact memory",
+    })).toBe("graph_memory_context_data_3");
+    expect(assembly.variables.graph_memory_context_data).toBe("owned elsewhere");
+    expect(assembly.variables.graph_memory_context_data_3).toBe("exact memory");
+  });
+
+  it("rejects invalid plugin-controlled variable names", () => {
+    expect(() => contributePromptDataContext({ contexts: [], variables: {} }, {
+      name: "graph-memory:recall",
+      text: "memory",
+      variableBase: "Graph-Memory",
+    })).toThrow(/invalid prompt data variable base/);
+  });
+});


### PR DESCRIPTION
## Root cause

DSH treats every dynamic context as prompt-template source. Graph Memory previously inserted recalled nodes and episodic messages directly into that source, so ordinary Vue, Handlebars, Liquid, Angular, or CI expressions could be parsed as DSH variables and abort the entire turn. Storage was not the problem; the missing data/template trust boundary was.

## Architectural fix

- Contribute recalled memory through DSH's one-pass variable-value channel.
- Keep the context template limited to one plugin-owned placeholder.
- Preserve historical code byte-for-byte; substituted values are not scanned again by DSH.
- Allocate a deterministic suffix instead of overwriting another provider's variable.
- Keep `assembleContext` host-neutral and centralize this contract in one reusable helper.

## Verification

- Real `@deepseek-ai/dsh-system-prompt@0.0.1-rc.1`: failure reproduced before the fix.
- Real renderer after the fix: render succeeds and Vue/Handlebars/GitHub Actions expressions are preserved exactly.
- 17 test files / 130 tests pass.
- `npm run build` and `npm run build:dsh` pass.

Thank you @meyaomiao for the detailed root-cause trace and local validation in #79, and @vongostev for independently reporting the same failure mode and emphasizing that even valid-looking variable names are unsafe in #80.

Closes #79
Closes #80