### PR TITLE
fix(dsh): replace instead of append compaction-capsule sources

### DIFF
--- a/dist/dsh.js
+++ b/dist/dsh.js
@@ -7,7 +7,7 @@
  */
 import { createHash, randomUUID } from "node:crypto";
 import { openDb } from "./src/store/db.js";
-import { allActiveNodes, findByName, getBySession, getStats, getVectorStats, getUnextracted, markExtracted, saveMessageOnce, updateNode, upsertEdge, upsertNode, } from "./src/store/store.js";
+import { allActiveNodes, findByName, getBySession, getStats, getVectorStats, getUnextracted, markExtracted, saveMessageOnce, updateNode, upsertEdge, upsertNode, replaceNodeSources, } from "./src/store/store.js";
 import { Extractor } from "./src/extractor/extract.js";
 import { Recaller } from "./src/recaller/recall.js";
 import { assembleContext } from "./src/format/assemble.js";
@@ -230,11 +230,15 @@ export function apply(ctx, input = {}) {
             name: stableName,
             description: "Consolidated checkpoint for an older span of one DSH conversation",
             content: summary,
-        }, sid, sources);
+        }, sid);
         const node = updateNode(db, result.node.name, {
             description: "Consolidated checkpoint for an older span of one DSH conversation",
             content: summary,
         }) ?? result.node;
+        // Replace, never append: a fresh summary supersedes the previously
+        // shadowed span. Keeping the node permanently pinned to every old
+        // message grows gm_node_sources without bound for long sessions.
+        replaceNodeSources(db, node.id, sid, sources);
         void recaller.syncEmbed(node);
         invalidateGraphCache();
     }

--- a/dist/src/store/store.js
+++ b/dist/src/store/store.js
@@ -83,6 +83,16 @@ export function saveNodeSources(db, nodeId, sessionId, sources) {
         insert.run(nodeId, sessionId, source.messageId);
     }
 }
+/**
+ * Replace (not append) the durable message sources of one graph node.
+ * Used for compaction capsule nodes: a fresh summary supersedes the
+ * previously shadowed span, so the node must reference only the most
+ * recent checkpoint instead of accumulating every old span forever.
+ */
+export function replaceNodeSources(db, nodeId, sessionId, sources) {
+    db.prepare("DELETE FROM gm_node_sources WHERE node_id=?").run(nodeId);
+    saveNodeSources(db, nodeId, sessionId, sources);
+}
 /** 按 name 精确更新 description / content；找不到返回 null（调用方决定报错语义） */
 export function updateNode(db, name, patch) {
     const ex = findByName(db, name);

--- a/dsh.ts
+++ b/dsh.ts
@@ -20,6 +20,7 @@ import {
   updateNode,
   upsertEdge,
   upsertNode,
+  replaceNodeSources,
 } from "./src/store/store.ts";
 import { Extractor } from "./src/extractor/extract.ts";
 import { Recaller } from "./src/recaller/recall.ts";
@@ -312,11 +313,15 @@ export function apply(ctx: DshContext, input: Config = {}): void {
       name: stableName,
       description: "Consolidated checkpoint for an older span of one DSH conversation",
       content: summary,
-    }, sid, sources);
+    }, sid);
     const node = updateNode(db, result.node.name, {
       description: "Consolidated checkpoint for an older span of one DSH conversation",
       content: summary,
     }) ?? result.node;
+    // Replace, never append: a fresh summary supersedes the previously
+    // shadowed span. Keeping the node permanently pinned to every old
+    // message grows gm_node_sources without bound for long sessions.
+    replaceNodeSources(db, node.id, sid, sources);
     void recaller.syncEmbed(node);
     invalidateGraphCache();
   }

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -111,6 +111,22 @@ export function saveNodeSources(
   }
 }
 
+/**
+ * Replace (not append) the durable message sources of one graph node.
+ * Used for compaction capsule nodes: a fresh summary supersedes the
+ * previously shadowed span, so the node must reference only the most
+ * recent checkpoint instead of accumulating every old span forever.
+ */
+export function replaceNodeSources(
+  db: DatabaseSyncInstance,
+  nodeId: string,
+  sessionId: string,
+  sources: Array<{ messageId: string; turnIndex: number }>,
+): void {
+  db.prepare("DELETE FROM gm_node_sources WHERE node_id=?").run(nodeId);
+  saveNodeSources(db, nodeId, sessionId, sources);
+}
+
 /** 按 name 精确更新 description / content；找不到返回 null（调用方决定报错语义） */
 export function updateNode(
   db: DatabaseSyncInstance,

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -13,7 +13,7 @@ import {
   mergeNodes, edgesFrom, edgesTo, allActiveNodes, allEdges,
   searchNodes, topNodes, graphWalk, getBySession,
   saveMessage, saveMessageOnce, getMessages, getUnextracted, markExtracted, getEpisodicMessages,
-  getNodeSourceMessages,
+  getNodeSourceMessages, replaceNodeSources,
   saveSignal, pendingSignals, markSignalsDone,
   getStats, saveVector, vectorSearch, getAllVectors, upsertCommunitySummary,
   vectorSearchWithScore,
@@ -70,6 +70,40 @@ describe("host event messages", () => {
     expect(getNodeSourceMessages(db, node.id, 1000).map(message => message.text)).toEqual([
       "the exact retained evidence",
     ]);
+  });
+});
+
+describe("compaction capsule sources", () => {
+  it("replaceNodeSources 替换而非追加：新 span 覆盖旧 span", () => {
+    saveMessageOnce(db, "dsh:s1:100", "dsh:s1", 100, "user", {
+      role: "user", content: [{ type: "text", text: "old span" }],
+    });
+    saveMessageOnce(db, "dsh:s1:200", "dsh:s1", 200, "user", {
+      role: "user", content: [{ type: "text", text: "new span" }],
+    });
+    const { node } = upsertNode(db, {
+      type: "EVENT", name: "session-memory-capsule", description: "", content: "summary v1",
+    }, "dsh:s1", [{ messageId: "dsh:s1:100", turnIndex: 100 }]);
+
+    // 第二次压缩：替换而非追加
+    replaceNodeSources(db, node.id, "dsh:s1", [{ messageId: "dsh:s1:200", turnIndex: 200 }]);
+
+    const texts = getNodeSourceMessages(db, node.id, 1000).map(message => message.text);
+    expect(texts).toEqual(["new span"]);
+    expect(texts).not.toContain("old span");
+  });
+
+  it("replaceNodeSources 空 sources 清空节点溯源", () => {
+    saveMessageOnce(db, "dsh:s1:100", "dsh:s1", 100, "user", {
+      role: "user", content: [{ type: "text", text: "old span" }],
+    });
+    const { node } = upsertNode(db, {
+      type: "EVENT", name: "session-memory-capsule-empty", description: "", content: "summary",
+    }, "dsh:s1", [{ messageId: "dsh:s1:100", turnIndex: 100 }]);
+
+    replaceNodeSources(db, node.id, "dsh:s1", []);
+
+    expect(getNodeSourceMessages(db, node.id, 1000)).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## 问题

`recordCompactionCapsule`（dsh.ts）每次 DSH 会话滚动压缩产生 `compaction/summary` 事件时，把被压缩掉的 `shadowedSeqs` **追加**为稳定名节点 `session-memory-<sha1(sid)[0:16]>` 的 source。由于：

1. 节点名由 session id 派生 → 同一会话永远 upsert 到**同一个节点**
2. `saveNodeSources` 纯 `INSERT OR IGNORE`，**无任何删除/上限/TTL**
3. 长会话反复压缩 → source 线性膨胀

实测：单一会话节点积累 **10559 条 source**，占全表 `gm_node_sources`（34392 行）的 **30.7%**；节点 content 只有最新一份摘要（12KB），却声称代表 1 万条消息。DB 体积膨胀至 123MB，且每次压缩都重新 embedding 摘要。

## 修复

- 新增 `replaceNodeSources(db, nodeId, sessionId, sources)`：DELETE 该节点全部旧 source 后 INSERT 本次，**替换而非追加**。
- `recordCompactionCapsule` 改为调用 `replaceNodeSources`：新摘要**取代**旧 span，节点永远只引用最近一份压缩。
- 提取器路径（真实知识节点）**语义不变**——它们的 source 累积是合理证据。

## 验证

- 新增 2 个针对性单测：替换语义（旧 span 消失、新 span 保留）+ 空 sources 清空溯源。
- 全量测试：**132/132 通过**（17 files），`tsc` 构建 exit 0。
- 行为验证（真实 DB 副本）：第 1 次压缩 20 条 source → 第 2 次 10 条（替换非追加）、旧 span 零残留、content 正常更新。

## 影响面

- 召回语义不变：`gm_node_sources` 唯一消费方是 `assembleContext` 的 episodic 溯源（`getNodeSourceMessages`），替换后溯源指向最近一份压缩的证据，更准确。
- 数据膨胀停止：长会话不再无限累积 source。
