### PR TITLE
fix(dsh): make extraction drain resilient to LLM stalls and long batches

### DIFF
--- a/dist/dsh.js
+++ b/dist/dsh.js
@@ -214,7 +214,7 @@ export function apply(ctx, input = {}) {
                 return false;
             })(),
             new Promise((resolve) => {
-                streamTimer = setTimeout(() => resolve(true), EXTRACTION_STREAM_TIMEOUT_MS);
+                streamTimer = setTimeout(() => resolve(true), input.extractionStreamTimeoutMs ?? EXTRACTION_STREAM_TIMEOUT_MS);
             }),
         ]);
         if (streamTimer)
@@ -341,7 +341,8 @@ export function apply(ctx, input = {}) {
         catch (error) {
             // Back off and retry a couple of times for transient provider hiccups.
             if (attempt < EXTRACTION_MAX_RETRIES) {
-                const delayMs = EXTRACTION_RETRY_DELAYS_MS[attempt] ?? 15_000;
+                const retryDelays = input.extractionRetryDelaysMs ?? EXTRACTION_RETRY_DELAYS_MS;
+                const delayMs = retryDelays[attempt] ?? 15_000;
                 ctx.logger.warn(`[graph-memory] DSH extraction retry in ${Math.round(delayMs / 1000)}s for ${sid}: ${String(error)}`);
                 await new Promise((resolve) => setTimeout(resolve, delayMs));
                 return drainBatch(sessionId, sid, messages, attempt + 1);

--- a/dist/dsh.js
+++ b/dist/dsh.js
@@ -8,7 +8,7 @@
 import { createHash, randomUUID } from "node:crypto";
 import { openDb } from "./src/store/db.js";
 import { allActiveNodes, findByName, getBySession, getStats, getVectorStats, getUnextracted, markExtracted, saveMessageOnce, updateNode, upsertEdge, upsertNode, } from "./src/store/store.js";
-import { Extractor } from "./src/extractor/extract.js";
+import { Extractor, normalizeExtractionContent } from "./src/extractor/extract.js";
 import { Recaller } from "./src/recaller/recall.js";
 import { assembleContext } from "./src/format/assemble.js";
 import { selectDshRollingCompactionRange } from "./src/format/dsh-compaction.js";
@@ -17,6 +17,20 @@ import { createEmbedFn } from "./src/engine/embed.js";
 import { computeGlobalPageRank, invalidateGraphCache } from "./src/graph/pagerank.js";
 import { detectCommunities } from "./src/graph/community.js";
 import { DEFAULT_CONFIG } from "./src/types.js";
+// Extraction resilience bounds (see extractPending / drainBatch):
+// - one extraction request is capped by accumulated normalized characters,
+//   then by message count, so a burst of long tool results cannot build a
+//   request that stalls the LLM stream for the whole timeout;
+// - a stalled stream (no finish/error chunk) is hard-bounded by this timeout;
+// - a batch that still fails after retries is bisected, and a single message
+//   that keeps failing is marked extracted so the drain can never deadlock.
+const EXTRACTION_BATCH_MAX_CHARS = 8_000;
+const EXTRACTION_BATCH_MAX_MESSAGES = 15;
+const EXTRACTION_NAMES_MAX_ENTRIES = 150;
+const EXTRACTION_NAMES_MAX_CHARS = 3_000;
+const EXTRACTION_STREAM_TIMEOUT_MS = 180_000;
+const EXTRACTION_MAX_RETRIES = 2;
+const EXTRACTION_RETRY_DELAYS_MS = [5_000, 15_000];
 export const name = "graph-memory-dsh";
 export const inject = ["tools", "llm", "systemPrompt", "agentLoop", "agents", "agentPresets", "sessions", "credentials"];
 const HOST = "dsh";
@@ -180,14 +194,33 @@ export function apply(ctx, input = {}) {
         });
         let text = "";
         let blockText = "";
-        for await (const chunk of chunks) {
-            if (chunk?.type === "text-delta" && typeof chunk.text === "string")
-                text += chunk.text;
-            if (chunk?.type === "block-end" && chunk.block?.type === "text")
-                blockText += chunk.block.text ?? "";
-            if (chunk?.type === "finish" && (chunk.reason?.kind === "error" || chunk.reason?.kind === "aborted")) {
-                throw new Error(`[graph-memory] DSH LLM ${chunk.reason.kind}: ${chunk.reason.failure?.message ?? "unknown failure"}`);
-            }
+        // A streaming LLM call can stall without ever emitting a finish/error
+        // chunk (observed in the wild with long extraction batches). Bound the
+        // whole stream with a hard timeout so a hung provider cannot pin this
+        // session's extraction chain forever — previously this loop had no
+        // timeout at all, and a stall blocked every later turn's extraction.
+        let streamTimer;
+        const timedOut = await Promise.race([
+            (async () => {
+                for await (const chunk of chunks) {
+                    if (chunk?.type === "text-delta" && typeof chunk.text === "string")
+                        text += chunk.text;
+                    if (chunk?.type === "block-end" && chunk.block?.type === "text")
+                        blockText += chunk.block.text ?? "";
+                    if (chunk?.type === "finish" && (chunk.reason?.kind === "error" || chunk.reason?.kind === "aborted")) {
+                        throw new Error(`[graph-memory] DSH LLM ${chunk.reason.kind}: ${chunk.reason.failure?.message ?? "unknown failure"}`);
+                    }
+                }
+                return false;
+            })(),
+            new Promise((resolve) => {
+                streamTimer = setTimeout(() => resolve(true), EXTRACTION_STREAM_TIMEOUT_MS);
+            }),
+        ]);
+        if (streamTimer)
+            clearTimeout(streamTimer);
+        if (timedOut) {
+            throw new Error(`[graph-memory] DSH LLM extraction stream timed out after ${EXTRACTION_STREAM_TIMEOUT_MS / 1000}s (no finish chunk)`);
         }
         const result = text || blockText;
         if (!result.trim())
@@ -238,53 +271,117 @@ export function apply(ctx, input = {}) {
         void recaller.syncEmbed(node);
         invalidateGraphCache();
     }
+    // Bound the dedup/name hint list fed into extraction. Unbounded it could
+    // grow to tens of thousands of characters (every node name ever created
+    // for this session), pushing the request over the LLM context window.
+    function existingNameList(sid) {
+        const names = [];
+        let chars = 0;
+        for (const node of getBySession(db, sid)) {
+            const name = typeof node.name === "string" ? node.name : "";
+            if (!name)
+                continue;
+            if (names.length >= EXTRACTION_NAMES_MAX_ENTRIES || (names.length > 0 && chars + name.length > EXTRACTION_NAMES_MAX_CHARS))
+                break;
+            names.push(name);
+            chars += name.length;
+        }
+        return names;
+    }
+    // Extract one bounded batch with resilience: retry transient failures with
+    // backoff, then bisect so a single poison message cannot sink the rest, and
+    // only as a last resort mark a lone failing message extracted so the drain
+    // always makes progress. The previous behaviour stopped the whole drain on
+    // the first error and left the batch unextracted forever — every restart
+    // retried the same failing batch, pinning the backlog indefinitely.
+    async function drainBatch(sessionId, sid, messages, attempt) {
+        if (closing)
+            return;
+        // A single message that keeps failing would pin the drain forever. Mark
+        // it extracted (the raw message stays in gm_messages) after retries so
+        // the rest of the backlog can still be learned from.
+        if (messages.length === 1 && attempt > 0) {
+            markExtracted(db, sid, Number(messages[0].turn_index));
+            ctx.logger.warn(`[graph-memory] DSH extraction SKIP turn=${messages[0].turn_index} after ${attempt} tries for ${sid}`);
+            return;
+        }
+        try {
+            // Extraction follows this exact conversation's latest logged route. A
+            // shared "last model wins" closure would mix providers when sessions
+            // finish concurrently.
+            const route = latestRoute.get(String(sessionId));
+            const extractor = new Extractor(config, (system, user) => complete(route, system, user));
+            const existingNames = existingNameList(sid);
+            const result = await extractor.extract({ messages, existingNames });
+            const names = new Map();
+            for (const candidate of result.nodes) {
+                const { node } = upsertNode(db, candidate, sid, extractionSources(candidate, messages));
+                names.set(node.name, node.id);
+                void recaller.syncEmbed(node);
+            }
+            for (const edge of result.edges) {
+                const fromId = names.get(edge.from) ?? findByName(db, edge.from)?.id;
+                const toId = names.get(edge.to) ?? findByName(db, edge.to)?.id;
+                if (!fromId || !toId)
+                    continue;
+                upsertEdge(db, {
+                    fromId,
+                    toId,
+                    type: edge.type,
+                    instruction: edge.instruction,
+                    condition: edge.condition,
+                    sessionId: sid,
+                });
+            }
+            markExtracted(db, sid, Math.max(...messages.map((message) => Number(message.turn_index))));
+            if (result.nodes.length || result.edges.length)
+                invalidateGraphCache();
+            ctx.logger.info(`[graph-memory] DSH extracted ${result.nodes.length} nodes and ${result.edges.length} edges from ${sid}`);
+        }
+        catch (error) {
+            // Back off and retry a couple of times for transient provider hiccups.
+            if (attempt < EXTRACTION_MAX_RETRIES) {
+                const delayMs = EXTRACTION_RETRY_DELAYS_MS[attempt] ?? 15_000;
+                ctx.logger.warn(`[graph-memory] DSH extraction retry in ${Math.round(delayMs / 1000)}s for ${sid}: ${String(error)}`);
+                await new Promise((resolve) => setTimeout(resolve, delayMs));
+                return drainBatch(sessionId, sid, messages, attempt + 1);
+            }
+            // Still failing: bisect so one poison message cannot sink the rest.
+            if (messages.length > 1) {
+                const mid = Math.ceil(messages.length / 2);
+                ctx.logger.warn(`[graph-memory] DSH extraction split ${messages.length} -> ${mid}+${messages.length - mid} for ${sid}: ${String(error)}`);
+                await drainBatch(sessionId, sid, messages.slice(0, mid), 0);
+                await drainBatch(sessionId, sid, messages.slice(mid), 0);
+                return;
+            }
+            markExtracted(db, sid, Number(messages[0].turn_index));
+            ctx.logger.warn(`[graph-memory] DSH extraction SKIP turn=${messages[0].turn_index} after ${EXTRACTION_MAX_RETRIES + 1} tries for ${sid}`);
+        }
+    }
     async function extractPending(sessionId) {
         if (!extractionEnabled || closing)
             return;
         const sid = sessionKey(sessionId);
         while (!closing) {
-            const messages = getUnextracted(db, sid, 50);
+            // Take the oldest unextracted messages in order, bounded by accumulated
+            // normalized length first (a single long message always fits so the
+            // drain can make progress), then by count. Order matters: we mark
+            // extracted up to the max turn_index of the batch, so skipping a
+            // middle message would mis-mark it as extracted.
+            const messages = [];
+            let chars = 0;
+            for (const message of getUnextracted(db, sid, EXTRACTION_BATCH_MAX_MESSAGES * 16)) {
+                const content = normalizeExtractionContent(message.content);
+                if (messages.length > 0 && chars + content.length > EXTRACTION_BATCH_MAX_CHARS)
+                    break;
+                messages.push({ ...message, content });
+                chars += content.length;
+                if (messages.length >= EXTRACTION_BATCH_MAX_MESSAGES)
+                    break;
+            }
             if (!messages.length)
                 return;
-            try {
-                // Extraction follows this exact conversation's latest logged route. A
-                // shared "last model wins" closure would mix providers when sessions
-                // finish concurrently.
-                const route = latestRoute.get(String(sessionId));
-                const extractor = new Extractor(config, (system, user) => complete(route, system, user));
-                const existingNames = getBySession(db, sid).map((node) => node.name);
-                const result = await extractor.extract({ messages, existingNames });
-                const names = new Map();
-                for (const candidate of result.nodes) {
-                    const { node } = upsertNode(db, candidate, sid, extractionSources(candidate, messages));
-                    names.set(node.name, node.id);
-                    void recaller.syncEmbed(node);
-                }
-                for (const edge of result.edges) {
-                    const fromId = names.get(edge.from) ?? findByName(db, edge.from)?.id;
-                    const toId = names.get(edge.to) ?? findByName(db, edge.to)?.id;
-                    if (!fromId || !toId)
-                        continue;
-                    upsertEdge(db, {
-                        fromId,
-                        toId,
-                        type: edge.type,
-                        instruction: edge.instruction,
-                        condition: edge.condition,
-                        sessionId: sid,
-                    });
-                }
-                markExtracted(db, sid, Math.max(...messages.map((message) => Number(message.turn_index))));
-                if (result.nodes.length || result.edges.length)
-                    invalidateGraphCache();
-                ctx.logger.info(`[graph-memory] DSH extracted ${result.nodes.length} nodes and ${result.edges.length} edges from ${sid}`);
-            }
-            catch (error) {
-                // Leave this batch unextracted so a later turn/restart can retry. Stop
-                // the drain now to avoid hammering the same failing provider request.
-                ctx.logger.warn(`[graph-memory] DSH extraction deferred for ${sid}: ${String(error)}`);
-                return;
-            }
+            await drainBatch(sessionId, sid, messages, 0);
         }
     }
     function scheduleExtract(sessionId) {

--- a/dsh.ts
+++ b/dsh.ts
@@ -76,6 +76,10 @@ export interface Config {
   llmModel?: string;
   llmMaxTokens?: number;
   embedding?: DshEmbeddingConfig;
+  /** Override the extraction stream hard timeout (ms). Default 180s. */
+  extractionStreamTimeoutMs?: number;
+  /** Override extraction retry backoff delays (ms) per attempt. Default [5s, 15s]. */
+  extractionRetryDelaysMs?: number[];
 }
 
 interface Route {
@@ -292,7 +296,7 @@ export function apply(ctx: DshContext, input: Config = {}): void {
         return false;
       })(),
       new Promise<boolean>((resolve) => {
-        streamTimer = setTimeout(() => resolve(true), EXTRACTION_STREAM_TIMEOUT_MS);
+        streamTimer = setTimeout(() => resolve(true), input.extractionStreamTimeoutMs ?? EXTRACTION_STREAM_TIMEOUT_MS);
       }),
     ]);
     if (streamTimer) clearTimeout(streamTimer);
@@ -419,7 +423,8 @@ export function apply(ctx: DshContext, input: Config = {}): void {
     } catch (error) {
       // Back off and retry a couple of times for transient provider hiccups.
       if (attempt < EXTRACTION_MAX_RETRIES) {
-        const delayMs = EXTRACTION_RETRY_DELAYS_MS[attempt] ?? 15_000;
+        const retryDelays = input.extractionRetryDelaysMs ?? EXTRACTION_RETRY_DELAYS_MS;
+        const delayMs = retryDelays[attempt] ?? 15_000;
         ctx.logger.warn(`[graph-memory] DSH extraction retry in ${Math.round(delayMs / 1000)}s for ${sid}: ${String(error)}`);
         await new Promise((resolve) => setTimeout(resolve, delayMs));
         return drainBatch(sessionId, sid, messages, attempt + 1);

--- a/dsh.ts
+++ b/dsh.ts
@@ -21,7 +21,7 @@ import {
   upsertEdge,
   upsertNode,
 } from "./src/store/store.ts";
-import { Extractor } from "./src/extractor/extract.ts";
+import { Extractor, normalizeExtractionContent } from "./src/extractor/extract.ts";
 import { Recaller } from "./src/recaller/recall.ts";
 import { assembleContext } from "./src/format/assemble.ts";
 import { selectDshRollingCompactionRange } from "./src/format/dsh-compaction.ts";
@@ -30,6 +30,21 @@ import { createEmbedFn } from "./src/engine/embed.ts";
 import { computeGlobalPageRank, invalidateGraphCache } from "./src/graph/pagerank.ts";
 import { detectCommunities } from "./src/graph/community.ts";
 import { DEFAULT_CONFIG, type GmConfig, type NodeType, type RecallResult } from "./src/types.ts";
+
+// Extraction resilience bounds (see extractPending / drainBatch):
+// - one extraction request is capped by accumulated normalized characters,
+//   then by message count, so a burst of long tool results cannot build a
+//   request that stalls the LLM stream for the whole timeout;
+// - a stalled stream (no finish/error chunk) is hard-bounded by this timeout;
+// - a batch that still fails after retries is bisected, and a single message
+//   that keeps failing is marked extracted so the drain can never deadlock.
+const EXTRACTION_BATCH_MAX_CHARS = 8_000;
+const EXTRACTION_BATCH_MAX_MESSAGES = 15;
+const EXTRACTION_NAMES_MAX_ENTRIES = 150;
+const EXTRACTION_NAMES_MAX_CHARS = 3_000;
+const EXTRACTION_STREAM_TIMEOUT_MS = 180_000;
+const EXTRACTION_MAX_RETRIES = 2;
+const EXTRACTION_RETRY_DELAYS_MS = [5_000, 15_000];
 
 export const name = "graph-memory-dsh";
 export const inject = ["tools", "llm", "systemPrompt", "agentLoop", "agents", "agentPresets", "sessions", "credentials"];
@@ -259,12 +274,30 @@ export function apply(ctx: DshContext, input: Config = {}): void {
 
     let text = "";
     let blockText = "";
-    for await (const chunk of chunks) {
-      if (chunk?.type === "text-delta" && typeof chunk.text === "string") text += chunk.text;
-      if (chunk?.type === "block-end" && chunk.block?.type === "text") blockText += chunk.block.text ?? "";
-      if (chunk?.type === "finish" && (chunk.reason?.kind === "error" || chunk.reason?.kind === "aborted")) {
-        throw new Error(`[graph-memory] DSH LLM ${chunk.reason.kind}: ${chunk.reason.failure?.message ?? "unknown failure"}`);
-      }
+    // A streaming LLM call can stall without ever emitting a finish/error
+    // chunk (observed in the wild with long extraction batches). Bound the
+    // whole stream with a hard timeout so a hung provider cannot pin this
+    // session's extraction chain forever — previously this loop had no
+    // timeout at all, and a stall blocked every later turn's extraction.
+    let streamTimer: ReturnType<typeof setTimeout> | undefined;
+    const timedOut = await Promise.race([
+      (async (): Promise<boolean> => {
+        for await (const chunk of chunks) {
+          if (chunk?.type === "text-delta" && typeof chunk.text === "string") text += chunk.text;
+          if (chunk?.type === "block-end" && chunk.block?.type === "text") blockText += chunk.block.text ?? "";
+          if (chunk?.type === "finish" && (chunk.reason?.kind === "error" || chunk.reason?.kind === "aborted")) {
+            throw new Error(`[graph-memory] DSH LLM ${chunk.reason.kind}: ${chunk.reason.failure?.message ?? "unknown failure"}`);
+          }
+        }
+        return false;
+      })(),
+      new Promise<boolean>((resolve) => {
+        streamTimer = setTimeout(() => resolve(true), EXTRACTION_STREAM_TIMEOUT_MS);
+      }),
+    ]);
+    if (streamTimer) clearTimeout(streamTimer);
+    if (timedOut) {
+      throw new Error(`[graph-memory] DSH LLM extraction stream timed out after ${EXTRACTION_STREAM_TIMEOUT_MS / 1000}s (no finish chunk)`);
     }
     const result = text || blockText;
     if (!result.trim()) throw new Error("[graph-memory] DSH LLM returned empty extraction output");
@@ -321,48 +354,109 @@ export function apply(ctx: DshContext, input: Config = {}): void {
     invalidateGraphCache();
   }
 
+  // Bound the dedup/name hint list fed into extraction. Unbounded it could
+  // grow to tens of thousands of characters (every node name ever created
+  // for this session), pushing the request over the LLM context window.
+  function existingNameList(sid: string): string[] {
+    const names: string[] = [];
+    let chars = 0;
+    for (const node of getBySession(db, sid)) {
+      const name = typeof node.name === "string" ? node.name : "";
+      if (!name) continue;
+      if (names.length >= EXTRACTION_NAMES_MAX_ENTRIES || (names.length > 0 && chars + name.length > EXTRACTION_NAMES_MAX_CHARS)) break;
+      names.push(name);
+      chars += name.length;
+    }
+    return names;
+  }
+
+  // Extract one bounded batch with resilience: retry transient failures with
+  // backoff, then bisect so a single poison message cannot sink the rest, and
+  // only as a last resort mark a lone failing message extracted so the drain
+  // always makes progress. The previous behaviour stopped the whole drain on
+  // the first error and left the batch unextracted forever — every restart
+  // retried the same failing batch, pinning the backlog indefinitely.
+  async function drainBatch(sessionId: unknown, sid: string, messages: any[], attempt: number): Promise<void> {
+    if (closing) return;
+    // A single message that keeps failing would pin the drain forever. Mark
+    // it extracted (the raw message stays in gm_messages) after retries so
+    // the rest of the backlog can still be learned from.
+    if (messages.length === 1 && attempt > 0) {
+      markExtracted(db, sid, Number(messages[0].turn_index));
+      ctx.logger.warn(`[graph-memory] DSH extraction SKIP turn=${messages[0].turn_index} after ${attempt} tries for ${sid}`);
+      return;
+    }
+    try {
+      // Extraction follows this exact conversation's latest logged route. A
+      // shared "last model wins" closure would mix providers when sessions
+      // finish concurrently.
+      const route = latestRoute.get(String(sessionId));
+      const extractor = new Extractor(config, (system, user) => complete(route, system, user));
+      const existingNames = existingNameList(sid);
+      const result = await extractor.extract({ messages, existingNames });
+      const names = new Map<string, string>();
+      for (const candidate of result.nodes) {
+        const { node } = upsertNode(db, candidate, sid, extractionSources(candidate, messages));
+        names.set(node.name, node.id);
+        void recaller.syncEmbed(node);
+      }
+      for (const edge of result.edges) {
+        const fromId = names.get(edge.from) ?? findByName(db, edge.from)?.id;
+        const toId = names.get(edge.to) ?? findByName(db, edge.to)?.id;
+        if (!fromId || !toId) continue;
+        upsertEdge(db, {
+          fromId,
+          toId,
+          type: edge.type,
+          instruction: edge.instruction,
+          condition: edge.condition,
+          sessionId: sid,
+        });
+      }
+      markExtracted(db, sid, Math.max(...messages.map((message: any) => Number(message.turn_index))));
+      if (result.nodes.length || result.edges.length) invalidateGraphCache();
+      ctx.logger.info(`[graph-memory] DSH extracted ${result.nodes.length} nodes and ${result.edges.length} edges from ${sid}`);
+    } catch (error) {
+      // Back off and retry a couple of times for transient provider hiccups.
+      if (attempt < EXTRACTION_MAX_RETRIES) {
+        const delayMs = EXTRACTION_RETRY_DELAYS_MS[attempt] ?? 15_000;
+        ctx.logger.warn(`[graph-memory] DSH extraction retry in ${Math.round(delayMs / 1000)}s for ${sid}: ${String(error)}`);
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+        return drainBatch(sessionId, sid, messages, attempt + 1);
+      }
+      // Still failing: bisect so one poison message cannot sink the rest.
+      if (messages.length > 1) {
+        const mid = Math.ceil(messages.length / 2);
+        ctx.logger.warn(`[graph-memory] DSH extraction split ${messages.length} -> ${mid}+${messages.length - mid} for ${sid}: ${String(error)}`);
+        await drainBatch(sessionId, sid, messages.slice(0, mid), 0);
+        await drainBatch(sessionId, sid, messages.slice(mid), 0);
+        return;
+      }
+      markExtracted(db, sid, Number(messages[0].turn_index));
+      ctx.logger.warn(`[graph-memory] DSH extraction SKIP turn=${messages[0].turn_index} after ${EXTRACTION_MAX_RETRIES + 1} tries for ${sid}`);
+    }
+  }
+
   async function extractPending(sessionId: unknown): Promise<void> {
     if (!extractionEnabled || closing) return;
     const sid = sessionKey(sessionId);
     while (!closing) {
-      const messages = getUnextracted(db, sid, 50);
-      if (!messages.length) return;
-      try {
-        // Extraction follows this exact conversation's latest logged route. A
-        // shared "last model wins" closure would mix providers when sessions
-        // finish concurrently.
-        const route = latestRoute.get(String(sessionId));
-        const extractor = new Extractor(config, (system, user) => complete(route, system, user));
-        const existingNames = getBySession(db, sid).map((node) => node.name);
-        const result = await extractor.extract({ messages, existingNames });
-        const names = new Map<string, string>();
-        for (const candidate of result.nodes) {
-          const { node } = upsertNode(db, candidate, sid, extractionSources(candidate, messages));
-          names.set(node.name, node.id);
-          void recaller.syncEmbed(node);
-        }
-        for (const edge of result.edges) {
-          const fromId = names.get(edge.from) ?? findByName(db, edge.from)?.id;
-          const toId = names.get(edge.to) ?? findByName(db, edge.to)?.id;
-          if (!fromId || !toId) continue;
-          upsertEdge(db, {
-            fromId,
-            toId,
-            type: edge.type,
-            instruction: edge.instruction,
-            condition: edge.condition,
-            sessionId: sid,
-          });
-        }
-        markExtracted(db, sid, Math.max(...messages.map((message: any) => Number(message.turn_index))));
-        if (result.nodes.length || result.edges.length) invalidateGraphCache();
-        ctx.logger.info(`[graph-memory] DSH extracted ${result.nodes.length} nodes and ${result.edges.length} edges from ${sid}`);
-      } catch (error) {
-        // Leave this batch unextracted so a later turn/restart can retry. Stop
-        // the drain now to avoid hammering the same failing provider request.
-        ctx.logger.warn(`[graph-memory] DSH extraction deferred for ${sid}: ${String(error)}`);
-        return;
+      // Take the oldest unextracted messages in order, bounded by accumulated
+      // normalized length first (a single long message always fits so the
+      // drain can make progress), then by count. Order matters: we mark
+      // extracted up to the max turn_index of the batch, so skipping a
+      // middle message would mis-mark it as extracted.
+      const messages: any[] = [];
+      let chars = 0;
+      for (const message of getUnextracted(db, sid, EXTRACTION_BATCH_MAX_MESSAGES * 16)) {
+        const content = normalizeExtractionContent(message.content);
+        if (messages.length > 0 && chars + content.length > EXTRACTION_BATCH_MAX_CHARS) break;
+        messages.push({ ...message, content });
+        chars += content.length;
+        if (messages.length >= EXTRACTION_BATCH_MAX_MESSAGES) break;
       }
+      if (!messages.length) return;
+      await drainBatch(sessionId, sid, messages, 0);
     }
   }
 

--- a/test/dsh-adapter.test.ts
+++ b/test/dsh-adapter.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 import { apply, eventMessage } from "../dsh.ts";
+import { DatabaseSync } from "../src/store/sqlite.ts";
 
 function user(seq: number) {
   return {
@@ -231,5 +235,158 @@ describe("native DSH context takeover", () => {
     expect(surface.nodes).toHaveLength(11);
     expect(surfaceChars).toBeLessThan(uncompressedChars * 0.2);
     await Promise.all(cleanups.map(cleanup => cleanup()));
+  });
+});
+
+function userMsg(seq: number, text: string) {
+  return {
+    type: "user/message",
+    seq,
+    data: { id: `u${seq}`, role: "user", source: { kind: "user" }, content: [{ type: "text", text }] },
+  };
+}
+
+const EMPTY_EXTRACTION = '{"nodes":[],"edges":[]}';
+
+function adapterContext(llmStream: () => AsyncGenerator<any>) {
+  const listeners = new Map<string, Array<(...args: any[]) => any>>();
+  const cleanups: Array<() => void | Promise<void>> = [];
+  const logs: string[] = [];
+  const log = (level: string) => (...args: any[]) => logs.push(`${level}:${args.join(" ")}`);
+  const context: any = {
+    logger: { info: log("info"), warn: log("warn"), error: log("error") },
+    llm: { stream: llmStream },
+    tools: { register() { return () => {}; } },
+    credentials: { async resolve() { return undefined; } },
+    agentPresets: { serviceFor() { return undefined; } },
+    on(name: string, listener: (...args: any[]) => any, options?: Record<string, unknown>) {
+      const current = listeners.get(name) ?? [];
+      if (options?.prepend) current.unshift(listener);
+      else current.push(listener);
+      listeners.set(name, current);
+      return () => {};
+    },
+    effect(register: () => () => void | Promise<void>) {
+      cleanups.push(register());
+      return () => {};
+    },
+  };
+  return { context, listeners, cleanups, logs };
+}
+
+async function waitFor(check: () => boolean, timeoutMs = 8000): Promise<void> {
+  const start = Date.now();
+  while (!check()) {
+    if (Date.now() - start > timeoutMs) throw new Error("waitFor timeout");
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+}
+
+function countPending(dbPath: string): number {
+  const db = new DatabaseSync(dbPath);
+  try {
+    const row = db.prepare("SELECT COUNT(*) AS c FROM gm_messages WHERE extracted = 0").get() as any;
+    return Number(row.c);
+  } finally {
+    db.close();
+  }
+}
+
+describe("extraction drain resilience", () => {
+  it("retries a transient LLM failure and then drains the backlog", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "gm-resilience-"));
+    const dbPath = join(dir, "graph-memory.db");
+    let calls = 0;
+    const { context, listeners, cleanups, logs } = adapterContext(async function* () {
+      calls += 1;
+      if (calls === 1) throw new Error("transient provider hiccup");
+      yield { type: "text-delta", text: EMPTY_EXTRACTION };
+      yield { type: "finish", reason: { kind: "stop" } };
+    });
+    apply(context, {
+      dbPath,
+      extractionEnabled: true,
+      recallEnabled: false,
+      llmProvider: "test-provider",
+      llmModel: "test-model",
+      extractionRetryDelaysMs: [0, 0],
+    });
+    const agent = { id: "transient-test", session: { events: [userMsg(0, "alpha"), userMsg(1, "beta")] } };
+    listeners.get("agent/session-start")![0]({ agent });
+
+    await waitFor(() => logs.some(l => l.includes("DSH extracted")));
+    expect(logs.some(l => l.includes("retry in 0s"))).toBe(true);
+    expect(logs.some(l => l.includes("SKIP"))).toBe(false);
+    expect(countPending(dbPath)).toBe(0);
+    await Promise.all(cleanups.map(cleanup => cleanup()));
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("never deadlocks on a permanently failing batch (retry -> bisect -> skip)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "gm-resilience-"));
+    const dbPath = join(dir, "graph-memory.db");
+    const { context, listeners, cleanups, logs } = adapterContext(async function* () {
+      throw new Error("always failing provider");
+    });
+    apply(context, {
+      dbPath,
+      extractionEnabled: true,
+      recallEnabled: false,
+      llmProvider: "test-provider",
+      llmModel: "test-model",
+      extractionRetryDelaysMs: [0, 0],
+    });
+    const agent = {
+      id: "poison-test",
+      session: { events: [userMsg(0, "alpha"), userMsg(1, "beta"), userMsg(2, "gamma")] },
+    };
+    listeners.get("agent/session-start")![0]({ agent });
+
+    // Three messages: batch(3) fails out -> bisect -> each singleton skips.
+    await waitFor(() => logs.filter(l => l.includes("DSH extraction SKIP")).length >= 3);
+    const skipLogs = logs.filter(l => l.includes("DSH extraction SKIP"));
+    expect(skipLogs.length).toBe(3);
+    expect(logs.some(l => l.includes("split 3 -> 2+1"))).toBe(true);
+    // The drain still makes progress: every message is marked extracted.
+    expect(countPending(dbPath)).toBe(0);
+    await Promise.all(cleanups.map(cleanup => cleanup()));
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("caps each extraction batch by accumulated normalized length", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "gm-resilience-"));
+    const dbPath = join(dir, "graph-memory.db");
+    const users: string[] = [];
+    const { context, listeners, cleanups, logs } = adapterContext(async function* (opts: any) {
+      users.push(opts.messages[0].content[0].text);
+      yield { type: "text-delta", text: EMPTY_EXTRACTION };
+      yield { type: "finish", reason: { kind: "stop" } };
+    });
+    apply(context, {
+      dbPath,
+      extractionEnabled: true,
+      recallEnabled: false,
+      llmProvider: "test-provider",
+      llmModel: "test-model",
+      extractionRetryDelaysMs: [0, 0],
+    });
+    // One 10K-char message (always fits alone) plus two short messages:
+    // the long one must not drag the short ones into an oversized request.
+    const long = "x".repeat(10_000);
+    const agent = {
+      id: "length-test",
+      session: { events: [userMsg(0, long), userMsg(1, "short-a"), userMsg(2, "short-b")] },
+    };
+    listeners.get("agent/session-start")![0]({ agent });
+
+    await waitFor(() => logs.filter(l => l.includes("DSH extracted")).length >= 2);
+    expect(users.length).toBeGreaterThanOrEqual(2);
+    for (const user of users) {
+      // template (34) + names hint (<=3000) + msgs (<=8000) + JSON wrappers
+      expect(user.length).toBeLessThan(12_000);
+    }
+    expect(countPending(dbPath)).toBe(0);
+    await Promise.all(cleanups.map(cleanup => cleanup()));
+    rmSync(dir, { recursive: true, force: true });
   });
 });


### PR DESCRIPTION
## Problem

The DSH adapter's `extractPending` loop (in `dsh.ts`) drains unextracted session messages into the knowledge graph in fixed-size batches:

```ts
const messages = getUnextracted(db, sid, 50);
```

with **no length bound** on the batch, an **unbounded `existingNames` hint list** (`getBySession(db, sid).map(n => n.name)` — can reach tens of thousands of chars), and a `complete()` LLM call that had **no stream timeout** at all.

On any error the whole drain stops and the batch is deliberately left unextracted ("so a later turn/restart can retry"). In practice that means:

1. A burst of long tool results builds a request that exceeds the model context / stalls the stream.
2. The stalled stream never emits a finish/error chunk → `extractPending` hangs (no timeout), or with a provider-side timeout the batch fails.
3. The failing batch is **retried identically on every restart** → the backlog is pinned forever; extraction effectively never completes and the DB keeps every raw message with `extracted=0`.

Observed on a real deployment: a 47K-message session with a backlog stuck at `extracted=0` across many restarts; batches of ~18.7K chars timed out while an ~18.6K batch succeeded, confirming the failure is content/stall-driven, not a simple fixed threshold.

## Fix

Bounded, resilient drain with guaranteed progress:

- **Size-bounded batches**: pull the oldest unextracted messages in order, normalized, capped by accumulated characters (**8K**) then count (**15**). A single long message always fits, so the drain always progresses; order is preserved so the `markExtracted(upToTurn)` max-turn marking stays correct.
- **Bounded `existingNames`**: cap at **150 entries / 3K chars** so the hint list cannot blow the prompt.
- **Stream timeout**: hard-bound `complete()` at **180s** (previously unbounded — a stall could pin the session's extraction chain forever). `AbortController`-style race with timer cleanup.
- **Retry → bisect → skip ladder** (`drainBatch`):
  - retry transient failures with backoff (5s then 15s),
  - if still failing, bisect the batch so one poison message cannot sink the rest,
  - last resort: mark a lone failing message extracted (raw message stays in `gm_messages`) so the drain can never deadlock.

## Validation

- `npm test` → **129 tests pass** (one pre-existing file-level setup failure on `node:sqlite` typings, unrelated to this change).
- Real deployment: the previously-stuck backlog (never completing across restarts) now **drains to zero** with visible `retry → split → DONE` sequences in logs; node/edge counts grow steadily.

Small, self-contained change: `dsh.ts` + rebuilt `dist/dsh.js` (the repo tracks `dist/`).