### PR TITLE
feat(dsh): add bounded raw-message retention

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ graph-memory/
 | Visible plugin state | **Done** | Active in Plugin Inventory |
 | Pro visual workbench | **Experimental** | Separate DSH Client Plugin with a read-only card snapshot |
 
-Current beta: `1.6.0-beta.9`. Functional acceptance used DeepSeek Harness `0.1.0-rc.8`; script-free Git installation and profile config composition were subsequently reverified against `0.1.1-rc.2`. Testing covered script-free Git and tarball installation, Web profile loading, configurable five-turn rolling compaction through the public agent-preset compaction service, exact source provenance, token-budget enforcement, high-precision automatic recall, FTS5 fallback, and the Pro Lite Host, Typed Remote, and Client bundle boundaries. All 130 automated tests passed. Real model-backed acceptance also verified rolling checkpoint replacement, 1024-dimensional `text-embedding-v4` vectors, and automatic cross-project recall without an explicit memory tool call.
+Current beta: `1.6.0-beta.10`. Functional acceptance used DeepSeek Harness `0.1.0-rc.8`; script-free Git installation and profile config composition were subsequently reverified against `0.1.1-rc.2`. Testing covered script-free Git and tarball installation, Web profile loading, configurable five-turn rolling compaction through the public agent-preset compaction service, exact source provenance, bounded raw-message retention, token-budget enforcement, high-precision automatic recall, FTS5 fallback, and the Pro Lite Host, Typed Remote, and Client bundle boundaries. All 139 automated tests passed. Real model-backed acceptance also verified rolling checkpoint replacement, 1024-dimensional `text-embedding-v4` vectors, and automatic cross-project recall without an explicit memory tool call.
 
 <p align="center">
   <strong>Plugin enabled: graph-memory/dsh is active in the DSH plugin list</strong><br>
@@ -226,7 +226,7 @@ cd graph-memory
 npm install
 npm test
 npm pack
-npx @deepseek-ai/dsh plugin --profile web add /absolute/path/to/graph-memory-1.6.0-beta.9.tgz
+npx @deepseek-ai/dsh plugin --profile web add /absolute/path/to/graph-memory-1.6.0-beta.10.tgz
 ```
 
 After installation, verify that `graph-memory/dsh` is enabled under **Settings → Plugins → Plugin list**.
@@ -257,14 +257,38 @@ Without embeddings, Graph Memory continues with FTS5 and does not block conversa
 
 ![Vector status](docs/images/dsh/vector-status.png)
 
+## Durable message retention (opt-in)
+
+DSH context compaction and SQLite retention are intentionally separate. Compaction bounds the model surface; it does not delete provenance from `gm_messages`. The default policy is `keep: all`, so upgrading never removes existing data.
+
+For large stores, configure `messageRetention` on `graph-memory/dsh` and roll it out in dry-run mode first:
+
+```yaml
+messageRetention:
+  keep: referenced
+  recentTurns: 20
+  retentionDays: 30
+  batchSize: 500
+  dryRun: true
+```
+
+- `all`: preserve every durable event; this is the default.
+- `referenced`: prune extracted, unreferenced rows; optional turn/day windows remain protected.
+- `recent`: requires `recentTurns` or `retentionDays`, and also always preserves referenced or pending rows.
+
+`recentTurns` counts real user turns per session and keeps their following assistant/tool events. When both windows are set, a row is eligible only after it falls outside both. Invalid timestamps are retained. Each maintenance tick uses one bounded transaction, re-checks `gm_node_sources`, and never runs `VACUUM` automatically.
+
+Before enabling deletion, back up `$DSH_HOME/graph-memory/graph-memory.db`, keep `dryRun: true`, run `gm_maintain`, and inspect `gm_stats`. Change `dryRun` to `false` only after the candidate receipt matches the intended policy.
+
 ## DSH tools
 
 | Tool | Purpose |
 |---|---|
-| `gm_status` | Plugin, store, extraction, recall, and vector state |
+| `gm_status` | Plugin, store, extraction, recall, vector, and retention state |
 | `gm_search` | Explicit long-term graph search |
 | `gm_record` | Persist a TASK, SKILL, or EVENT |
-| `gm_stats` | Node, edge, type, and community statistics |
+| `gm_stats` | Graph, durable-message, and retention receipts/statistics |
+| `gm_maintain` | Run one bounded graph + configured retention maintenance tick |
 
 Automatic recall does not require an explicit `gm_search` tool call. The plugin retrieves relevant memory during Prompt Assembly.
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -178,7 +178,7 @@ graph-memory/
 | 插件状态可见 | **已完成** | 设置页 Plugin Inventory 显示 active |
 | Pro 可视化工作台 | **实验版可用** | 独立 DSH Client Plugin，当前为只读卡片式快照 |
 
-当前 beta：`1.6.0-beta.9`。完整功能验收宿主为 DeepSeek Harness `0.1.0-rc.8`；随后又在 `0.1.1-rc.2` 上复验了无脚本 Git 安装与 profile 配置组合。验收已覆盖无安装脚本的 Git 与 tarball 安装、Web profile 原生加载、通过 Agent 公共 compaction 服务执行的可配置最近 5 轮滚动压缩、精确原文溯源、token 预算、高精度自动召回、FTS5 降级，以及 Pro Lite Host、Typed Remote 和 Client bundle 边界；130 项自动化测试通过。真实模型验收还完成了滚动 checkpoint 替换、`text-embedding-v4` 1024 维向量写入，以及不调用记忆工具的跨项目自动召回。
+当前 beta：`1.6.0-beta.10`。完整功能验收宿主为 DeepSeek Harness `0.1.0-rc.8`；随后又在 `0.1.1-rc.2` 上复验了无脚本 Git 安装与 profile 配置组合。验收已覆盖无安装脚本的 Git 与 tarball 安装、Web profile 原生加载、通过 Agent 公共 compaction 服务执行的可配置最近 5 轮滚动压缩、精确原文溯源、有界原始消息保留策略、token 预算、高精度自动召回、FTS5 降级，以及 Pro Lite Host、Typed Remote 和 Client bundle 边界；139 项自动化测试通过。真实模型验收还完成了滚动 checkpoint 替换、`text-embedding-v4` 1024 维向量写入，以及不调用记忆工具的跨项目自动召回。
 
 <p align="center">
   <strong>插件已启用：graph-memory/dsh 在 DSH 插件列表中处于 active</strong><br>
@@ -208,7 +208,7 @@ cd graph-memory
 npm install
 npm test
 npm pack
-npx @deepseek-ai/dsh plugin --profile web add /absolute/path/to/graph-memory-1.6.0-beta.9.tgz
+npx @deepseek-ai/dsh plugin --profile web add /absolute/path/to/graph-memory-1.6.0-beta.10.tgz
 ```
 
 安装后，在 **设置 → 插件 → 插件列表 → graph-memory/dsh** 中确认状态为“已启用”。默认数据库路径：
@@ -237,14 +237,38 @@ dsh web
   <img src="docs/images/dsh/vector-status.png" alt="Graph Memory 向量状态" width="78%">
 </p>
 
+### 原始消息保留策略（显式启用）
+
+DSH 上下文压缩与 SQLite 数据保留是两件事：压缩只限制模型表面上下文，不会自动删除 `gm_messages` 中的溯源证据。默认策略是 `keep: all`，因此升级不会删除任何现有数据。
+
+数据库较大时，可在 `graph-memory/dsh` 配置中加入 `messageRetention`。第一次必须先使用 dry-run：
+
+```yaml
+messageRetention:
+  keep: referenced
+  recentTurns: 20
+  retentionDays: 30
+  batchSize: 500
+  dryRun: true
+```
+
+- `all`：保留全部持久事件，默认值。
+- `referenced`：只清理已经抽取且没有 `gm_node_sources` 引用的消息；可叠加最近轮次/天数保护窗口。
+- `recent`：必须配置 `recentTurns` 或 `retentionDays`；仍然无条件保护来源引用和待抽取消息。
+
+`recentTurns` 按每个 Session 的真实用户轮次计算，并保留后续 assistant/tool 事件。两个窗口同时存在时，只有同时超出两个窗口的消息才有资格清理；时间戳异常的消息会保守保留。每次维护只执行一个有上限的事务，删除前再次检查来源引用，不会自动执行 `VACUUM`。
+
+启用真实删除前，请备份 `$DSH_HOME/graph-memory/graph-memory.db`，保持 `dryRun: true`，调用一次 `gm_maintain` 并检查 `gm_stats` 回执；候选范围符合预期后再改为 `false`。
+
 ### DSH 原生工具
 
 | 工具 | 作用 |
 |---|---|
-| `gm_status` | 查看插件、数据库、抽取、召回和向量状态 |
+| `gm_status` | 查看插件、数据库、抽取、召回、向量和保留策略状态 |
 | `gm_search` | 主动搜索长期知识图谱 |
 | `gm_record` | 确定性记录 TASK、SKILL 或 EVENT |
-| `gm_stats` | 查看节点、边、类型与社区统计 |
+| `gm_stats` | 查看图谱、原始消息和保留策略回执/统计 |
+| `gm_maintain` | 执行一次有界图维护与已配置的消息保留批次 |
 
 自动召回不要求模型主动调用 `gm_search`；适配器会在 Prompt Assembly 阶段检索并注入相关记忆。
 

--- a/cordis.patch.yml
+++ b/cordis.patch.yml
@@ -10,6 +10,15 @@
         autoRecallMinScore: 0.6
         recallTokenBudget: 4096
         maintenanceInterval: 6
+        # Durable events are separate from the compacted model surface. The
+        # safe default never deletes raw messages. To opt in, first use
+        # keep: referenced with dryRun: true and inspect gm_stats/gm_maintain.
+        messageRetention:
+          keep: all
+          recentTurns: 0
+          retentionDays: 0
+          batchSize: 500
+          dryRun: false
         # Graph Memory retains the newest real user turns and asks the agent's
         # public DSH compaction provider to summarize/replace the older prefix.
         contextCompactionEnabled: true

--- a/dist/dsh.js
+++ b/dist/dsh.js
@@ -17,6 +17,7 @@ import { createEmbedFn } from "./src/engine/embed.js";
 import { computeGlobalPageRank, invalidateGraphCache } from "./src/graph/pagerank.js";
 import { detectCommunities } from "./src/graph/community.js";
 import { DEFAULT_CONFIG } from "./src/types.js";
+import { messageRetentionPolicyRevision, normalizeMessageRetentionPolicy, runMessageRetention, } from "./src/store/retention.js";
 export const name = "graph-memory-dsh";
 export const inject = ["tools", "llm", "systemPrompt", "agentLoop", "agents", "agentPresets", "sessions", "credentials"];
 const HOST = "dsh";
@@ -96,6 +97,11 @@ export function apply(ctx, input = {}) {
     if (!Number.isFinite(autoRecallMinScore) || autoRecallMinScore < 0 || autoRecallMinScore > 1) {
         throw new TypeError(`[graph-memory] autoRecallMinScore must be between 0 and 1, received ${autoRecallMinScore}`);
     }
+    const maintenanceInterval = input.maintenanceInterval ?? DEFAULT_CONFIG.compactTurnCount;
+    if (!Number.isInteger(maintenanceInterval) || maintenanceInterval < 1) {
+        throw new TypeError(`[graph-memory] maintenanceInterval must be a positive integer, received ${maintenanceInterval}`);
+    }
+    const messageRetention = normalizeMessageRetentionPolicy(input.messageRetention);
     const credentialRef = input.embedding?.apiKeyEnv;
     if (credentialRef && !/^[A-Za-z_][A-Za-z0-9_]*$/.test(credentialRef)) {
         throw new TypeError(`[graph-memory] embedding.apiKeyEnv must be a credential reference, received ${JSON.stringify(credentialRef)}`);
@@ -109,7 +115,7 @@ export function apply(ctx, input = {}) {
     const config = {
         ...DEFAULT_CONFIG,
         dbPath: input.dbPath ?? "~/.dsh/graph-memory/graph-memory.db",
-        compactTurnCount: input.maintenanceInterval ?? DEFAULT_CONFIG.compactTurnCount,
+        compactTurnCount: maintenanceInterval,
         recallMaxNodes: input.recallMaxNodes ?? DEFAULT_CONFIG.recallMaxNodes,
         recallMaxDepth: input.recallMaxDepth ?? DEFAULT_CONFIG.recallMaxDepth,
         embedding,
@@ -134,6 +140,14 @@ export function apply(ctx, input = {}) {
         succeeded: 0,
         unavailable: 0,
         failed: 0,
+    };
+    const retentionMetrics = {
+        runs: 0,
+        dryRuns: 0,
+        selectedRows: 0,
+        deletedRows: 0,
+        deletedBytes: 0,
+        last: undefined,
     };
     if (embeddingConfigured) {
         void createEmbedFn(embedding).then(async (embed) => {
@@ -297,20 +311,55 @@ export function apply(ctx, input = {}) {
                 extractChain.delete(key);
         });
     }
+    function runConfiguredRetention() {
+        const result = runMessageRetention(db, messageRetention);
+        retentionMetrics.runs += 1;
+        if (result.dryRun)
+            retentionMetrics.dryRuns += 1;
+        retentionMetrics.selectedRows += result.selectedRows;
+        retentionMetrics.deletedRows += result.deletedRows;
+        retentionMetrics.deletedBytes += result.deletedBytes;
+        retentionMetrics.last = result;
+        if (result.selectedRows > 0) {
+            const action = result.dryRun ? "would prune" : "pruned";
+            ctx.logger.info(`[graph-memory] retention ${action} ${result.dryRun ? result.selectedRows : result.deletedRows} ` +
+                `unreferenced extracted messages (${result.selectedBytes} estimated bytes, more=${result.hasMore})`);
+        }
+        return result;
+    }
+    function runGraphMaintenance() {
+        invalidateGraphCache();
+        const pagerank = computeGlobalPageRank(db, config);
+        const communities = detectCommunities(db);
+        return { pagerankNodes: pagerank.scores.size, communities: communities.count };
+    }
+    function runMaintenanceTick() {
+        const result = { errors: [] };
+        try {
+            result.graph = runGraphMaintenance();
+        }
+        catch (error) {
+            const message = `graph maintenance failed: ${String(error)}`;
+            result.errors.push(message);
+            ctx.logger.warn(`[graph-memory] DSH ${message}`);
+        }
+        try {
+            result.retention = runConfiguredRetention();
+        }
+        catch (error) {
+            const message = `message retention failed: ${String(error)}`;
+            result.errors.push(message);
+            ctx.logger.warn(`[graph-memory] DSH ${message}`);
+        }
+        return result;
+    }
     function maintain(sessionId) {
         const key = String(sessionId);
         const turns = (turnCounts.get(key) ?? 0) + 1;
         turnCounts.set(key, turns);
         if (turns % config.compactTurnCount !== 0)
             return;
-        try {
-            invalidateGraphCache();
-            computeGlobalPageRank(db, config);
-            detectCommunities(db);
-        }
-        catch (error) {
-            ctx.logger.warn(`[graph-memory] DSH graph maintenance failed: ${String(error)}`);
-        }
+        runMaintenanceTick();
     }
     function backfill(agent) {
         const id = agent?.id ?? agent?.session?.id;
@@ -478,7 +527,9 @@ export function apply(ctx, input = {}) {
             const embeddingModel = embeddingConfigured && input.embedding?.model
                 ? ` (${input.embedding.model})`
                 : "";
-            return `Graph Memory active (DSH native)\nStore: ${config.dbPath}\nNodes: ${stats.totalNodes}\nEdges: ${stats.totalEdges}\nExtraction: ${extractionEnabled ? "enabled" : "disabled"}\nRecall: ${recallEnabled ? "enabled" : "disabled"}\nEmbedding: ${embeddingState}${embeddingModel}\nVectors: ${vectors.count}/${stats.totalNodes}${vectors.dimensions.length ? ` (${vectors.dimensions.join(", ")} dimensions)` : ""}\nRolling compaction: attached=${compactionMetrics.attached}, selected=${compactionMetrics.selected}, succeeded=${compactionMetrics.succeeded}, unavailable=${compactionMetrics.unavailable}, failed=${compactionMetrics.failed}`;
+            const messageCount = Number(db.prepare("SELECT COUNT(*) AS count FROM gm_messages").get()?.count ?? 0);
+            const retentionRevision = messageRetentionPolicyRevision(messageRetention);
+            return `Graph Memory active (DSH native)\nStore: ${config.dbPath}\nNodes: ${stats.totalNodes}\nEdges: ${stats.totalEdges}\nMessages: ${messageCount}\nExtraction: ${extractionEnabled ? "enabled" : "disabled"}\nRecall: ${recallEnabled ? "enabled" : "disabled"}\nEmbedding: ${embeddingState}${embeddingModel}\nVectors: ${vectors.count}/${stats.totalNodes}${vectors.dimensions.length ? ` (${vectors.dimensions.join(", ")} dimensions)` : ""}\nMessage retention: keep=${messageRetention.keep}, recentTurns=${messageRetention.recentTurns}, retentionDays=${messageRetention.retentionDays}, batchSize=${messageRetention.batchSize}, dryRun=${messageRetention.dryRun}, revision=${retentionRevision}\nRetention GC: runs=${retentionMetrics.runs}, dryRuns=${retentionMetrics.dryRuns}, selected=${retentionMetrics.selectedRows}, deleted=${retentionMetrics.deletedRows}, estimatedDeletedBytes=${retentionMetrics.deletedBytes}\nRolling compaction: attached=${compactionMetrics.attached}, selected=${compactionMetrics.selected}, succeeded=${compactionMetrics.succeeded}, unavailable=${compactionMetrics.unavailable}, failed=${compactionMetrics.failed}`;
         },
     });
     ctx.tools.register({
@@ -528,13 +579,21 @@ export function apply(ctx, input = {}) {
     });
     ctx.tools.register({
         name: "gm_stats",
-        description: "Show Graph Memory node, edge and community counts.",
+        description: "Show Graph Memory graph, durable-message and retention statistics.",
         parameters: { type: "object", properties: {}, additionalProperties: false },
         output: stringOutput("Graph Memory statistics"),
         execute: async () => {
             const stats = getStats(db);
-            return `Nodes: ${stats.totalNodes}\nEdges: ${stats.totalEdges}\nCommunities: ${stats.communities}\nBy type: ${JSON.stringify(stats.byType)}`;
+            const messageCount = Number(db.prepare("SELECT COUNT(*) AS count FROM gm_messages").get()?.count ?? 0);
+            return `Nodes: ${stats.totalNodes}\nEdges: ${stats.totalEdges}\nCommunities: ${stats.communities}\nMessages: ${messageCount}\nBy type: ${JSON.stringify(stats.byType)}\nRetention policy: ${JSON.stringify({ ...messageRetention, revision: messageRetentionPolicyRevision(messageRetention) })}\nRetention totals: ${JSON.stringify({ runs: retentionMetrics.runs, dryRuns: retentionMetrics.dryRuns, selectedRows: retentionMetrics.selectedRows, deletedRows: retentionMetrics.deletedRows, deletedBytes: retentionMetrics.deletedBytes })}\nLast retention receipt: ${JSON.stringify(retentionMetrics.last ?? null)}`;
         },
+    });
+    ctx.tools.register({
+        name: "gm_maintain",
+        description: "Run one bounded Graph Memory maintenance tick using the configured retention policy.",
+        parameters: { type: "object", properties: {}, additionalProperties: false },
+        output: stringOutput("Graph Memory maintenance"),
+        execute: async () => JSON.stringify(runMaintenanceTick()),
     });
     ctx.effect(() => async () => {
         closing = true;
@@ -545,5 +604,10 @@ export function apply(ctx, input = {}) {
         turnCounts.clear();
         db.close();
     }, "graph-memory.close");
+    if (messageRetention.keep !== "all") {
+        const mode = messageRetention.dryRun ? "dry-run" : "deletion enabled";
+        ctx.logger.warn(`[graph-memory] durable message retention is ${mode} (${JSON.stringify(messageRetention)}). ` +
+            `Back up ${config.dbPath} before the first non-dry run; VACUUM remains a separate admin action.`);
+    }
     ctx.logger.info(`[graph-memory] native DSH adapter active at ${config.dbPath}`);
 }

--- a/dist/src/store/db.js
+++ b/dist/src/store/db.js
@@ -72,11 +72,19 @@ function migrate(db) {
         m7_community_signature,
         m8_backfill_community_signatures,
         m9_node_sources,
+        m10_message_retention_index,
     ];
     for (let i = cur; i < steps.length; i++) {
         steps[i](db);
         db.prepare("INSERT INTO _migrations (v,at) VALUES (?,?)").run(i + 1, Date.now());
     }
+}
+// ─── 有界原始消息保留策略查询 ────────────────────────────────
+function m10_message_retention_index(db) {
+    db.exec(`
+    CREATE INDEX IF NOT EXISTS ix_gm_msg_retention
+    ON gm_messages(extracted, created_at, session_id, turn_index);
+  `);
 }
 // ─── 精确溯源：图节点 → 原始消息 ──────────────────────────────
 function m9_node_sources(db) {

--- a/dist/src/store/retention.js
+++ b/dist/src/store/retention.js
@@ -1,0 +1,178 @@
+/**
+ * Durable raw-message retention for host adapters.
+ *
+ * Context compaction changes the model surface; it is not permission to
+ * delete durable evidence. This module therefore defaults to keep=all and
+ * only prunes rows that are extracted and unreferenced by graph provenance.
+ */
+import { createHash } from "node:crypto";
+export const DEFAULT_MESSAGE_RETENTION = Object.freeze({
+    keep: "all",
+    recentTurns: 0,
+    retentionDays: 0,
+    batchSize: 500,
+    dryRun: false,
+});
+function boundedInteger(value, name, fallback, minimum, maximum) {
+    if (value === undefined)
+        return fallback;
+    if (!Number.isInteger(value) || Number(value) < minimum || Number(value) > maximum) {
+        throw new TypeError(`[graph-memory] messageRetention.${name} must be an integer between ${minimum} and ${maximum}, received ${String(value)}`);
+    }
+    return Number(value);
+}
+/** Validate once before opening the database. Invalid policies fail closed. */
+export function normalizeMessageRetentionPolicy(input) {
+    if (input === undefined)
+        return { ...DEFAULT_MESSAGE_RETENTION };
+    if (!input || typeof input !== "object" || Array.isArray(input)) {
+        throw new TypeError("[graph-memory] messageRetention must be an object");
+    }
+    const keep = input.keep ?? "all";
+    if (keep !== "all" && keep !== "referenced" && keep !== "recent") {
+        throw new TypeError(`[graph-memory] messageRetention.keep must be all, referenced, or recent, received ${String(keep)}`);
+    }
+    const recentTurns = boundedInteger(input.recentTurns, "recentTurns", 0, 0, 100_000);
+    const retentionDays = boundedInteger(input.retentionDays, "retentionDays", 0, 0, 36_500);
+    const batchSize = boundedInteger(input.batchSize, "batchSize", 500, 1, 10_000);
+    const dryRun = input.dryRun ?? false;
+    if (typeof dryRun !== "boolean") {
+        throw new TypeError(`[graph-memory] messageRetention.dryRun must be a boolean, received ${String(dryRun)}`);
+    }
+    if (keep === "recent" && recentTurns === 0 && retentionDays === 0) {
+        throw new TypeError("[graph-memory] messageRetention.keep=recent requires recentTurns or retentionDays");
+    }
+    return { keep, recentTurns, retentionDays, batchSize, dryRun };
+}
+export function messageRetentionPolicyRevision(policy) {
+    return createHash("sha256")
+        .update(JSON.stringify(policy))
+        .digest("hex")
+        .slice(0, 12);
+}
+function emptyResult(policy, cutoffAt, start) {
+    return {
+        policy: policy.keep,
+        policyRevision: messageRetentionPolicyRevision(policy),
+        dryRun: policy.dryRun,
+        selectedRows: 0,
+        selectedBytes: 0,
+        deletedRows: 0,
+        deletedBytes: 0,
+        selectedSessions: 0,
+        byRole: {},
+        oldestCreatedAt: null,
+        newestCreatedAt: null,
+        hasMore: false,
+        cutoffAt,
+        durationMs: Date.now() - start,
+    };
+}
+function selectCandidates(db, policy, cutoffAt) {
+    const params = [];
+    let recentJoin = "";
+    let recentClause = "";
+    if (policy.recentTurns > 0) {
+        recentJoin = `
+      LEFT JOIN (
+        SELECT session_id, MIN(turn_index) AS cutoff_turn
+        FROM (
+          SELECT session_id, turn_index,
+            ROW_NUMBER() OVER (PARTITION BY session_id ORDER BY turn_index DESC) AS user_rank
+          FROM gm_messages
+          WHERE role='user'
+        ) ranked_users
+        WHERE user_rank <= ?
+        GROUP BY session_id
+      ) recent ON recent.session_id=m.session_id
+    `;
+        recentClause = "AND recent.cutoff_turn IS NOT NULL AND m.turn_index < recent.cutoff_turn";
+        params.push(policy.recentTurns);
+    }
+    let ageClause = "";
+    if (policy.retentionDays > 0) {
+        const ageCutoff = cutoffAt - policy.retentionDays * 86_400_000;
+        // Missing, zero, negative and future timestamps fail closed to retention.
+        ageClause = "AND m.created_at > 0 AND m.created_at < ?";
+        params.push(ageCutoff);
+    }
+    params.push(policy.batchSize + 1);
+    const rows = db.prepare(`
+    SELECT m.id, m.session_id, m.role, m.created_at,
+      length(CAST(m.content AS BLOB)) AS content_bytes
+    FROM gm_messages m
+    ${recentJoin}
+    WHERE m.extracted=1
+      AND NOT EXISTS (
+        SELECT 1 FROM gm_node_sources source WHERE source.message_id=m.id
+      )
+      ${recentClause}
+      ${ageClause}
+    ORDER BY m.created_at, m.session_id, m.turn_index, m.id
+    LIMIT ?
+  `).all(...params);
+    const hasMore = rows.length > policy.batchSize;
+    if (hasMore)
+        rows.pop();
+    return { rows, hasMore };
+}
+/**
+ * Run one bounded retention batch.
+ *
+ * A write-intent transaction freezes the candidate/reference boundary across
+ * connections. The DELETE still re-checks extracted state and provenance so
+ * a future refactor cannot silently turn candidate selection into authority.
+ * VACUUM is intentionally separate: deleting rows is the policy operation;
+ * rewriting the whole database file is an explicit administrative choice.
+ */
+export function runMessageRetention(db, policy, now = Date.now()) {
+    const start = Date.now();
+    if (policy.keep === "all")
+        return emptyResult(policy, now, start);
+    db.exec(policy.dryRun ? "BEGIN" : "BEGIN IMMEDIATE");
+    try {
+        const { rows, hasMore } = selectCandidates(db, policy, now);
+        const selectedBytes = rows.reduce((total, row) => total + Number(row.content_bytes || 0), 0);
+        let deletedRows = 0;
+        if (!policy.dryRun && rows.length) {
+            const placeholders = rows.map(() => "?").join(",");
+            const deleted = db.prepare(`
+        DELETE FROM gm_messages
+        WHERE id IN (${placeholders})
+          AND extracted=1
+          AND NOT EXISTS (
+            SELECT 1 FROM gm_node_sources source WHERE source.message_id=gm_messages.id
+          )
+      `).run(...rows.map((row) => row.id));
+            deletedRows = Number(deleted.changes);
+        }
+        db.exec("COMMIT");
+        const byRole = {};
+        for (const row of rows)
+            byRole[row.role] = (byRole[row.role] ?? 0) + 1;
+        const created = rows.map((row) => Number(row.created_at)).filter(Number.isFinite);
+        return {
+            policy: policy.keep,
+            policyRevision: messageRetentionPolicyRevision(policy),
+            dryRun: policy.dryRun,
+            selectedRows: rows.length,
+            selectedBytes,
+            deletedRows,
+            deletedBytes: deletedRows === rows.length ? selectedBytes : 0,
+            selectedSessions: new Set(rows.map((row) => row.session_id)).size,
+            byRole,
+            oldestCreatedAt: created.length ? Math.min(...created) : null,
+            newestCreatedAt: created.length ? Math.max(...created) : null,
+            hasMore,
+            cutoffAt: now,
+            durationMs: Date.now() - start,
+        };
+    }
+    catch (error) {
+        try {
+            db.exec("ROLLBACK");
+        }
+        catch { /* preserve the original error */ }
+        throw error;
+    }
+}

--- a/docs/DSH_NATIVE_PLAN.md
+++ b/docs/DSH_NATIVE_PLAN.md
@@ -1,7 +1,7 @@
 # Graph Memory × DeepSeek Harness 原生架构与 Pro 路线图
 
-> 更新：2026-08-21
-> Community 状态：`1.6.0-beta.9` 已完成 DSH rc.8 原生加载、滚动上下文接管、无安装脚本分发与真实跨项目召回验证
+> 更新：2026-08-30
+> Community 状态：`1.6.0-beta.10` 已完成 DSH 原生加载、滚动上下文接管、无安装脚本分发、可选原始消息保留策略与真实跨项目召回验证
 > Pro 状态：SQLite GraphSnapshot、DSH Host、Typed Remote 与只读 Client 已实现；2D/3D、分屏和拖拽尚未实现
 
 ## 1. 结论
@@ -12,7 +12,7 @@ Graph Memory 可以在不修改 DeepSeek Harness 核心代码的前提下，作�
 - Plugin Inventory 显示 `graph-memory/dsh` active；
 - Session 事件幂等摄取，SQLite 跨会话持久化；
 - `system-prompt/assemble` 自动注入召回结果；
-- `gm_status`、`gm_search`、`gm_record`、`gm_stats` 可用；
+- `gm_status`、`gm_search`、`gm_record`、`gm_stats`、`gm_maintain` 可用；
 - FTS5 与 OpenAI-compatible embedding 双路径；
 - DSH credentials 引用，不把 API key 放入 Cordis 配置；
 - 旧节点启动时自动补向量，显式写入等待向量完成；
@@ -86,6 +86,12 @@ graph-memory/
 
 Graph Memory 负责“何时压、保留几轮、压缩结果如何进入长期图记忆”；DSH CompactionEngine 负责安全的摘要生成、工具配对校验和 surface replacement 事务。两者是策略层与宿主执行层的组合，不是互不相干的两套系统。
 
+### 持久消息保留链路
+
+模型 surface 压缩不是删除 `gm_messages` 的授权。DSH adapter 的持久层默认 `messageRetention.keep=all`；只有用户显式选择 `referenced/recent` 才运行 GC。候选必须同时满足：已完成抽取、没有 `gm_node_sources` 引用、超出配置的用户轮次与天数窗口。候选选择和删除使用同一个 `BEGIN IMMEDIATE` 事务，DELETE 前再次检查引用，每个 tick 受 `batchSize` 限制。
+
+dry-run 与真实删除返回相同结构的回执，包括候选/删除行数、估算内容字节、角色、Session 数、时间范围、是否还有下一批和配置 revision。`gm_status/gm_stats` 暴露有效策略和累计结果；`gm_maintain` 可手动执行一个维护 tick。`VACUUM` 不属于保留保证，必须作为独立管理操作。无效配置在打开数据库前报错，默认升级路径不会删除数据。
+
 ## 5. Embedding 与凭据设计
 
 Cordis patch 只声明：
@@ -116,7 +122,7 @@ embedding:
 | 跨会话语义召回 | 不同措辞、无显式 `gm_search` 仍命中 |
 | 重启持久化 | 通过 |
 | 无 embedding 降级 | FTS5，通过 |
-| 单元/迁移/组合测试 | 127/127（含滚动压缩、溯源、预算、高精度召回和 Pro Lite） |
+| 单元/迁移/组合测试 | 139/139（含滚动压缩、溯源、消息保留、预算、高精度召回和 Pro Lite） |
 | TypeScript build | 通过 |
 | 真实模型滚动压缩 | DSH rc.8 上通过；第 6 个真实用户轮次触发最旧完整前缀替换 |
 | 真实跨项目召回 | 新项目不调用 `gm_search`，自动召回并准确回答 |

--- a/dsh.ts
+++ b/dsh.ts
@@ -30,6 +30,13 @@ import { createEmbedFn } from "./src/engine/embed.ts";
 import { computeGlobalPageRank, invalidateGraphCache } from "./src/graph/pagerank.ts";
 import { detectCommunities } from "./src/graph/community.ts";
 import { DEFAULT_CONFIG, type GmConfig, type NodeType, type RecallResult } from "./src/types.ts";
+import {
+  messageRetentionPolicyRevision,
+  normalizeMessageRetentionPolicy,
+  runMessageRetention,
+  type MessageRetentionConfig,
+  type MessageRetentionResult,
+} from "./src/store/retention.ts";
 
 export const name = "graph-memory-dsh";
 export const inject = ["tools", "llm", "systemPrompt", "agentLoop", "agents", "agentPresets", "sessions", "credentials"];
@@ -53,6 +60,8 @@ export interface Config {
   /** Maximum Graph Memory prompt tokens injected for one DSH request. */
   recallTokenBudget?: number;
   maintenanceInterval?: number;
+  /** Durable raw-message retention. Defaults to keep=all (no deletion). */
+  messageRetention?: MessageRetentionConfig;
   /** Keep this many newest real user turns verbatim on the DSH model surface. */
   freshTurnCount?: number;
   /** Use DSH's public compaction service to replace older surface history. */
@@ -170,6 +179,11 @@ export function apply(ctx: DshContext, input: Config = {}): void {
   if (!Number.isFinite(autoRecallMinScore) || autoRecallMinScore < 0 || autoRecallMinScore > 1) {
     throw new TypeError(`[graph-memory] autoRecallMinScore must be between 0 and 1, received ${autoRecallMinScore}`);
   }
+  const maintenanceInterval = input.maintenanceInterval ?? DEFAULT_CONFIG.compactTurnCount;
+  if (!Number.isInteger(maintenanceInterval) || maintenanceInterval < 1) {
+    throw new TypeError(`[graph-memory] maintenanceInterval must be a positive integer, received ${maintenanceInterval}`);
+  }
+  const messageRetention = normalizeMessageRetentionPolicy(input.messageRetention);
   const credentialRef = input.embedding?.apiKeyEnv;
   if (credentialRef && !/^[A-Za-z_][A-Za-z0-9_]*$/.test(credentialRef)) {
     throw new TypeError(`[graph-memory] embedding.apiKeyEnv must be a credential reference, received ${JSON.stringify(credentialRef)}`);
@@ -183,7 +197,7 @@ export function apply(ctx: DshContext, input: Config = {}): void {
   const config: GmConfig = {
     ...DEFAULT_CONFIG,
     dbPath: input.dbPath ?? "~/.dsh/graph-memory/graph-memory.db",
-    compactTurnCount: input.maintenanceInterval ?? DEFAULT_CONFIG.compactTurnCount,
+    compactTurnCount: maintenanceInterval,
     recallMaxNodes: input.recallMaxNodes ?? DEFAULT_CONFIG.recallMaxNodes,
     recallMaxDepth: input.recallMaxDepth ?? DEFAULT_CONFIG.recallMaxDepth,
     embedding,
@@ -211,6 +225,14 @@ export function apply(ctx: DshContext, input: Config = {}): void {
     succeeded: 0,
     unavailable: 0,
     failed: 0,
+  };
+  const retentionMetrics = {
+    runs: 0,
+    dryRuns: 0,
+    selectedRows: 0,
+    deletedRows: 0,
+    deletedBytes: 0,
+    last: undefined as MessageRetentionResult | undefined,
   };
 
   if (embeddingConfigured) {
@@ -376,18 +398,64 @@ export function apply(ctx: DshContext, input: Config = {}): void {
     });
   }
 
+  function runConfiguredRetention(): MessageRetentionResult {
+    const result = runMessageRetention(db, messageRetention);
+    retentionMetrics.runs += 1;
+    if (result.dryRun) retentionMetrics.dryRuns += 1;
+    retentionMetrics.selectedRows += result.selectedRows;
+    retentionMetrics.deletedRows += result.deletedRows;
+    retentionMetrics.deletedBytes += result.deletedBytes;
+    retentionMetrics.last = result;
+    if (result.selectedRows > 0) {
+      const action = result.dryRun ? "would prune" : "pruned";
+      ctx.logger.info(
+        `[graph-memory] retention ${action} ${result.dryRun ? result.selectedRows : result.deletedRows} ` +
+        `unreferenced extracted messages (${result.selectedBytes} estimated bytes, more=${result.hasMore})`,
+      );
+    }
+    return result;
+  }
+
+  function runGraphMaintenance(): { pagerankNodes: number; communities: number } {
+    invalidateGraphCache();
+    const pagerank = computeGlobalPageRank(db, config);
+    const communities = detectCommunities(db);
+    return { pagerankNodes: pagerank.scores.size, communities: communities.count };
+  }
+
+  function runMaintenanceTick(): {
+    graph?: { pagerankNodes: number; communities: number };
+    retention?: MessageRetentionResult;
+    errors: string[];
+  } {
+    const result: {
+      graph?: { pagerankNodes: number; communities: number };
+      retention?: MessageRetentionResult;
+      errors: string[];
+    } = { errors: [] };
+    try {
+      result.graph = runGraphMaintenance();
+    } catch (error) {
+      const message = `graph maintenance failed: ${String(error)}`;
+      result.errors.push(message);
+      ctx.logger.warn(`[graph-memory] DSH ${message}`);
+    }
+    try {
+      result.retention = runConfiguredRetention();
+    } catch (error) {
+      const message = `message retention failed: ${String(error)}`;
+      result.errors.push(message);
+      ctx.logger.warn(`[graph-memory] DSH ${message}`);
+    }
+    return result;
+  }
+
   function maintain(sessionId: unknown): void {
     const key = String(sessionId);
     const turns = (turnCounts.get(key) ?? 0) + 1;
     turnCounts.set(key, turns);
     if (turns % config.compactTurnCount !== 0) return;
-    try {
-      invalidateGraphCache();
-      computeGlobalPageRank(db, config);
-      detectCommunities(db);
-    } catch (error) {
-      ctx.logger.warn(`[graph-memory] DSH graph maintenance failed: ${String(error)}`);
-    }
+    runMaintenanceTick();
   }
 
   function backfill(agent: any): void {
@@ -570,7 +638,9 @@ export function apply(ctx: DshContext, input: Config = {}): void {
       const embeddingModel = embeddingConfigured && input.embedding?.model
         ? ` (${input.embedding.model})`
         : "";
-      return `Graph Memory active (DSH native)\nStore: ${config.dbPath}\nNodes: ${stats.totalNodes}\nEdges: ${stats.totalEdges}\nExtraction: ${extractionEnabled ? "enabled" : "disabled"}\nRecall: ${recallEnabled ? "enabled" : "disabled"}\nEmbedding: ${embeddingState}${embeddingModel}\nVectors: ${vectors.count}/${stats.totalNodes}${vectors.dimensions.length ? ` (${vectors.dimensions.join(", ")} dimensions)` : ""}\nRolling compaction: attached=${compactionMetrics.attached}, selected=${compactionMetrics.selected}, succeeded=${compactionMetrics.succeeded}, unavailable=${compactionMetrics.unavailable}, failed=${compactionMetrics.failed}`;
+      const messageCount = Number((db.prepare("SELECT COUNT(*) AS count FROM gm_messages").get() as any)?.count ?? 0);
+      const retentionRevision = messageRetentionPolicyRevision(messageRetention);
+      return `Graph Memory active (DSH native)\nStore: ${config.dbPath}\nNodes: ${stats.totalNodes}\nEdges: ${stats.totalEdges}\nMessages: ${messageCount}\nExtraction: ${extractionEnabled ? "enabled" : "disabled"}\nRecall: ${recallEnabled ? "enabled" : "disabled"}\nEmbedding: ${embeddingState}${embeddingModel}\nVectors: ${vectors.count}/${stats.totalNodes}${vectors.dimensions.length ? ` (${vectors.dimensions.join(", ")} dimensions)` : ""}\nMessage retention: keep=${messageRetention.keep}, recentTurns=${messageRetention.recentTurns}, retentionDays=${messageRetention.retentionDays}, batchSize=${messageRetention.batchSize}, dryRun=${messageRetention.dryRun}, revision=${retentionRevision}\nRetention GC: runs=${retentionMetrics.runs}, dryRuns=${retentionMetrics.dryRuns}, selected=${retentionMetrics.selectedRows}, deleted=${retentionMetrics.deletedRows}, estimatedDeletedBytes=${retentionMetrics.deletedBytes}\nRolling compaction: attached=${compactionMetrics.attached}, selected=${compactionMetrics.selected}, succeeded=${compactionMetrics.succeeded}, unavailable=${compactionMetrics.unavailable}, failed=${compactionMetrics.failed}`;
     },
   });
 
@@ -622,13 +692,22 @@ export function apply(ctx: DshContext, input: Config = {}): void {
 
   ctx.tools.register({
     name: "gm_stats",
-    description: "Show Graph Memory node, edge and community counts.",
+    description: "Show Graph Memory graph, durable-message and retention statistics.",
     parameters: { type: "object", properties: {}, additionalProperties: false },
     output: stringOutput("Graph Memory statistics"),
     execute: async () => {
       const stats = getStats(db);
-      return `Nodes: ${stats.totalNodes}\nEdges: ${stats.totalEdges}\nCommunities: ${stats.communities}\nBy type: ${JSON.stringify(stats.byType)}`;
+      const messageCount = Number((db.prepare("SELECT COUNT(*) AS count FROM gm_messages").get() as any)?.count ?? 0);
+      return `Nodes: ${stats.totalNodes}\nEdges: ${stats.totalEdges}\nCommunities: ${stats.communities}\nMessages: ${messageCount}\nBy type: ${JSON.stringify(stats.byType)}\nRetention policy: ${JSON.stringify({ ...messageRetention, revision: messageRetentionPolicyRevision(messageRetention) })}\nRetention totals: ${JSON.stringify({ runs: retentionMetrics.runs, dryRuns: retentionMetrics.dryRuns, selectedRows: retentionMetrics.selectedRows, deletedRows: retentionMetrics.deletedRows, deletedBytes: retentionMetrics.deletedBytes })}\nLast retention receipt: ${JSON.stringify(retentionMetrics.last ?? null)}`;
     },
+  });
+
+  ctx.tools.register({
+    name: "gm_maintain",
+    description: "Run one bounded Graph Memory maintenance tick using the configured retention policy.",
+    parameters: { type: "object", properties: {}, additionalProperties: false },
+    output: stringOutput("Graph Memory maintenance"),
+    execute: async () => JSON.stringify(runMaintenanceTick()),
   });
 
   ctx.effect(() => async () => {
@@ -641,5 +720,12 @@ export function apply(ctx: DshContext, input: Config = {}): void {
     db.close();
   }, "graph-memory.close");
 
+  if (messageRetention.keep !== "all") {
+    const mode = messageRetention.dryRun ? "dry-run" : "deletion enabled";
+    ctx.logger.warn(
+      `[graph-memory] durable message retention is ${mode} (${JSON.stringify(messageRetention)}). ` +
+      `Back up ${config.dbPath} before the first non-dry run; VACUUM remains a separate admin action.`,
+    );
+  }
   ctx.logger.info(`[graph-memory] native DSH adapter active at ${config.dbPath}`);
 }

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "graph-memory",
   "name": "Graph Memory",
-  "version": "1.6.0-beta.9",
+  "version": "1.6.0-beta.10",
   "description": "知识图谱记忆引擎：从对话提取三元组，FTS5+图遍历+PageRank 跨对话召回，社区聚类+向量去重自动维护",
   "contracts": {
     "tools": ["gm_search", "gm_record", "gm_update", "gm_stats", "gm_maintain"]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graph-memory",
-  "version": "1.6.0-beta.9",
+  "version": "1.6.0-beta.10",
   "description": "Knowledge graph memory for DeepSeek Harness and OpenClaw — cross-session recall, PageRank, communities, and vector search",
   "keywords": [
     "deepseek-harness",

--- a/src/store/db.ts
+++ b/src/store/db.ts
@@ -79,11 +79,21 @@ function migrate(db: DatabaseSyncInstance): void {
     m7_community_signature,
     m8_backfill_community_signatures,
     m9_node_sources,
+    m10_message_retention_index,
   ];
   for (let i = cur; i < steps.length; i++) {
     steps[i](db);
     db.prepare("INSERT INTO _migrations (v,at) VALUES (?,?)").run(i + 1, Date.now());
   }
+}
+
+// ─── 有界原始消息保留策略查询 ────────────────────────────────
+
+function m10_message_retention_index(db: DatabaseSyncInstance): void {
+  db.exec(`
+    CREATE INDEX IF NOT EXISTS ix_gm_msg_retention
+    ON gm_messages(extracted, created_at, session_id, turn_index);
+  `);
 }
 
 // ─── 精确溯源：图节点 → 原始消息 ──────────────────────────────

--- a/src/store/retention.ts
+++ b/src/store/retention.ts
@@ -1,0 +1,263 @@
+/**
+ * Durable raw-message retention for host adapters.
+ *
+ * Context compaction changes the model surface; it is not permission to
+ * delete durable evidence. This module therefore defaults to keep=all and
+ * only prunes rows that are extracted and unreferenced by graph provenance.
+ */
+import { createHash } from "node:crypto";
+import type { DatabaseSyncInstance } from "./sqlite.ts";
+
+export type MessageRetentionMode = "all" | "referenced" | "recent";
+
+export interface MessageRetentionConfig {
+  /** all keeps every raw row; referenced/recent opt in to bounded pruning. */
+  keep?: MessageRetentionMode;
+  /** Preserve this many newest real user turns in every session. */
+  recentTurns?: number;
+  /** Preserve rows ingested within this many days. */
+  retentionDays?: number;
+  /** Maximum rows considered by one maintenance tick. */
+  batchSize?: number;
+  /** Report candidates without deleting them. */
+  dryRun?: boolean;
+}
+
+export interface NormalizedMessageRetentionPolicy {
+  keep: MessageRetentionMode;
+  recentTurns: number;
+  retentionDays: number;
+  batchSize: number;
+  dryRun: boolean;
+}
+
+export interface MessageRetentionResult {
+  policy: MessageRetentionMode;
+  policyRevision: string;
+  dryRun: boolean;
+  selectedRows: number;
+  selectedBytes: number;
+  deletedRows: number;
+  deletedBytes: number;
+  selectedSessions: number;
+  byRole: Record<string, number>;
+  oldestCreatedAt: number | null;
+  newestCreatedAt: number | null;
+  hasMore: boolean;
+  cutoffAt: number;
+  durationMs: number;
+}
+
+interface CandidateRow {
+  id: string;
+  session_id: string;
+  role: string;
+  created_at: number;
+  content_bytes: number;
+}
+
+export const DEFAULT_MESSAGE_RETENTION: Readonly<NormalizedMessageRetentionPolicy> = Object.freeze({
+  keep: "all",
+  recentTurns: 0,
+  retentionDays: 0,
+  batchSize: 500,
+  dryRun: false,
+});
+
+function boundedInteger(
+  value: unknown,
+  name: string,
+  fallback: number,
+  minimum: number,
+  maximum: number,
+): number {
+  if (value === undefined) return fallback;
+  if (!Number.isInteger(value) || Number(value) < minimum || Number(value) > maximum) {
+    throw new TypeError(
+      `[graph-memory] messageRetention.${name} must be an integer between ${minimum} and ${maximum}, received ${String(value)}`,
+    );
+  }
+  return Number(value);
+}
+
+/** Validate once before opening the database. Invalid policies fail closed. */
+export function normalizeMessageRetentionPolicy(
+  input: MessageRetentionConfig | undefined,
+): NormalizedMessageRetentionPolicy {
+  if (input === undefined) return { ...DEFAULT_MESSAGE_RETENTION };
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new TypeError("[graph-memory] messageRetention must be an object");
+  }
+
+  const keep = input.keep ?? "all";
+  if (keep !== "all" && keep !== "referenced" && keep !== "recent") {
+    throw new TypeError(
+      `[graph-memory] messageRetention.keep must be all, referenced, or recent, received ${String(keep)}`,
+    );
+  }
+  const recentTurns = boundedInteger(input.recentTurns, "recentTurns", 0, 0, 100_000);
+  const retentionDays = boundedInteger(input.retentionDays, "retentionDays", 0, 0, 36_500);
+  const batchSize = boundedInteger(input.batchSize, "batchSize", 500, 1, 10_000);
+  const dryRun = input.dryRun ?? false;
+  if (typeof dryRun !== "boolean") {
+    throw new TypeError(
+      `[graph-memory] messageRetention.dryRun must be a boolean, received ${String(dryRun)}`,
+    );
+  }
+  if (keep === "recent" && recentTurns === 0 && retentionDays === 0) {
+    throw new TypeError(
+      "[graph-memory] messageRetention.keep=recent requires recentTurns or retentionDays",
+    );
+  }
+
+  return { keep, recentTurns, retentionDays, batchSize, dryRun };
+}
+
+export function messageRetentionPolicyRevision(
+  policy: NormalizedMessageRetentionPolicy,
+): string {
+  return createHash("sha256")
+    .update(JSON.stringify(policy))
+    .digest("hex")
+    .slice(0, 12);
+}
+
+function emptyResult(
+  policy: NormalizedMessageRetentionPolicy,
+  cutoffAt: number,
+  start: number,
+): MessageRetentionResult {
+  return {
+    policy: policy.keep,
+    policyRevision: messageRetentionPolicyRevision(policy),
+    dryRun: policy.dryRun,
+    selectedRows: 0,
+    selectedBytes: 0,
+    deletedRows: 0,
+    deletedBytes: 0,
+    selectedSessions: 0,
+    byRole: {},
+    oldestCreatedAt: null,
+    newestCreatedAt: null,
+    hasMore: false,
+    cutoffAt,
+    durationMs: Date.now() - start,
+  };
+}
+
+function selectCandidates(
+  db: DatabaseSyncInstance,
+  policy: NormalizedMessageRetentionPolicy,
+  cutoffAt: number,
+): { rows: CandidateRow[]; hasMore: boolean } {
+  const params: Array<number> = [];
+  let recentJoin = "";
+  let recentClause = "";
+  if (policy.recentTurns > 0) {
+    recentJoin = `
+      LEFT JOIN (
+        SELECT session_id, MIN(turn_index) AS cutoff_turn
+        FROM (
+          SELECT session_id, turn_index,
+            ROW_NUMBER() OVER (PARTITION BY session_id ORDER BY turn_index DESC) AS user_rank
+          FROM gm_messages
+          WHERE role='user'
+        ) ranked_users
+        WHERE user_rank <= ?
+        GROUP BY session_id
+      ) recent ON recent.session_id=m.session_id
+    `;
+    recentClause = "AND recent.cutoff_turn IS NOT NULL AND m.turn_index < recent.cutoff_turn";
+    params.push(policy.recentTurns);
+  }
+
+  let ageClause = "";
+  if (policy.retentionDays > 0) {
+    const ageCutoff = cutoffAt - policy.retentionDays * 86_400_000;
+    // Missing, zero, negative and future timestamps fail closed to retention.
+    ageClause = "AND m.created_at > 0 AND m.created_at < ?";
+    params.push(ageCutoff);
+  }
+
+  params.push(policy.batchSize + 1);
+  const rows = db.prepare(`
+    SELECT m.id, m.session_id, m.role, m.created_at,
+      length(CAST(m.content AS BLOB)) AS content_bytes
+    FROM gm_messages m
+    ${recentJoin}
+    WHERE m.extracted=1
+      AND NOT EXISTS (
+        SELECT 1 FROM gm_node_sources source WHERE source.message_id=m.id
+      )
+      ${recentClause}
+      ${ageClause}
+    ORDER BY m.created_at, m.session_id, m.turn_index, m.id
+    LIMIT ?
+  `).all(...params) as unknown as CandidateRow[];
+
+  const hasMore = rows.length > policy.batchSize;
+  if (hasMore) rows.pop();
+  return { rows, hasMore };
+}
+
+/**
+ * Run one bounded retention batch.
+ *
+ * A write-intent transaction freezes the candidate/reference boundary across
+ * connections. The DELETE still re-checks extracted state and provenance so
+ * a future refactor cannot silently turn candidate selection into authority.
+ * VACUUM is intentionally separate: deleting rows is the policy operation;
+ * rewriting the whole database file is an explicit administrative choice.
+ */
+export function runMessageRetention(
+  db: DatabaseSyncInstance,
+  policy: NormalizedMessageRetentionPolicy,
+  now: number = Date.now(),
+): MessageRetentionResult {
+  const start = Date.now();
+  if (policy.keep === "all") return emptyResult(policy, now, start);
+
+  db.exec(policy.dryRun ? "BEGIN" : "BEGIN IMMEDIATE");
+  try {
+    const { rows, hasMore } = selectCandidates(db, policy, now);
+    const selectedBytes = rows.reduce((total, row) => total + Number(row.content_bytes || 0), 0);
+    let deletedRows = 0;
+
+    if (!policy.dryRun && rows.length) {
+      const placeholders = rows.map(() => "?").join(",");
+      const deleted = db.prepare(`
+        DELETE FROM gm_messages
+        WHERE id IN (${placeholders})
+          AND extracted=1
+          AND NOT EXISTS (
+            SELECT 1 FROM gm_node_sources source WHERE source.message_id=gm_messages.id
+          )
+      `).run(...rows.map((row) => row.id));
+      deletedRows = Number(deleted.changes);
+    }
+
+    db.exec("COMMIT");
+    const byRole: Record<string, number> = {};
+    for (const row of rows) byRole[row.role] = (byRole[row.role] ?? 0) + 1;
+    const created = rows.map((row) => Number(row.created_at)).filter(Number.isFinite);
+    return {
+      policy: policy.keep,
+      policyRevision: messageRetentionPolicyRevision(policy),
+      dryRun: policy.dryRun,
+      selectedRows: rows.length,
+      selectedBytes,
+      deletedRows,
+      deletedBytes: deletedRows === rows.length ? selectedBytes : 0,
+      selectedSessions: new Set(rows.map((row) => row.session_id)).size,
+      byRole,
+      oldestCreatedAt: created.length ? Math.min(...created) : null,
+      newestCreatedAt: created.length ? Math.max(...created) : null,
+      hasMore,
+      cutoffAt: now,
+      durationMs: Date.now() - start,
+    };
+  } catch (error) {
+    try { db.exec("ROLLBACK"); } catch { /* preserve the original error */ }
+    throw error;
+  }
+}

--- a/test/dsh-adapter.test.ts
+++ b/test/dsh-adapter.test.ts
@@ -11,6 +11,63 @@ function user(seq: number) {
 }
 
 describe("native DSH context takeover", () => {
+  it("fails closed on an ambiguous destructive retention policy", () => {
+    expect(() => apply({} as any, {
+      dbPath: ":memory:",
+      messageRetention: { keep: "recent" },
+    })).toThrow(/requires recentTurns or retentionDays/);
+  });
+
+  it("exposes the effective retention policy and bounded maintenance receipt", async () => {
+    const tools = new Map<string, any>();
+    const cleanups: Array<() => void | Promise<void>> = [];
+    const context: any = {
+      logger: { info() {}, warn() {}, error() {} },
+      llm: { async *stream() {} },
+      tools: {
+        register(definition: any) {
+          tools.set(definition.name, definition);
+          return () => {};
+        },
+      },
+      credentials: { async resolve() { return undefined; } },
+      agentPresets: { serviceFor() { return undefined; } },
+      on() { return () => {}; },
+      effect(register: () => () => void | Promise<void>) {
+        cleanups.push(register());
+        return () => {};
+      },
+    };
+    apply(context, {
+      dbPath: ":memory:",
+      extractionEnabled: false,
+      recallEnabled: false,
+      messageRetention: {
+        keep: "referenced",
+        recentTurns: 5,
+        batchSize: 25,
+        dryRun: true,
+      },
+    });
+
+    const status = await tools.get("gm_status").execute();
+    expect(status).toContain("Message retention: keep=referenced");
+    expect(status).toContain("recentTurns=5");
+    expect(status).toContain("dryRun=true");
+
+    const receipt = JSON.parse(await tools.get("gm_maintain").execute());
+    expect(receipt.retention).toMatchObject({
+      policy: "referenced",
+      dryRun: true,
+      selectedRows: 0,
+      deletedRows: 0,
+    });
+    const stats = await tools.get("gm_stats").execute();
+    expect(stats).toContain('"dryRuns":1');
+    expect(stats).toContain("Last retention receipt:");
+    await Promise.all(cleanups.map(cleanup => cleanup()));
+  });
+
   it("keeps immutable source events but does not duplicate derived replacements", () => {
     expect(eventMessage({
       type: "assistant/message",

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -64,6 +64,8 @@ export function createTestDb(): DatabaseSyncInstance {
       created_at  INTEGER NOT NULL
     );
     CREATE INDEX IF NOT EXISTS ix_gm_msg_session ON gm_messages(session_id, turn_index);
+    CREATE INDEX IF NOT EXISTS ix_gm_msg_retention
+      ON gm_messages(extracted, created_at, session_id, turn_index);
   `);
 
   // m3: 信号

--- a/test/message-retention.test.ts
+++ b/test/message-retention.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  normalizeMessageRetentionPolicy,
+  runMessageRetention,
+} from "../src/store/retention.ts";
+import { createTestDb, insertNode } from "./helpers.ts";
+
+function insertMessage(
+  db: ReturnType<typeof createTestDb>,
+  id: string,
+  session: string,
+  turn: number,
+  role: string,
+  options: { extracted?: number; createdAt?: number; content?: string } = {},
+) {
+  db.prepare(`
+    INSERT INTO gm_messages
+      (id, session_id, turn_index, role, content, extracted, created_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    id,
+    session,
+    turn,
+    role,
+    options.content ?? `${role}-${turn}`,
+    options.extracted ?? 1,
+    options.createdAt ?? 1_700_000_000_000 + turn,
+  );
+}
+
+function ids(db: ReturnType<typeof createTestDb>): string[] {
+  return (db.prepare("SELECT id FROM gm_messages ORDER BY id").all() as Array<{ id: string }>)
+    .map((row) => row.id);
+}
+
+describe("message retention policy", () => {
+  it("defaults to keep=all and preserves every row exactly", () => {
+    const db = createTestDb();
+    insertMessage(db, "extracted", "s1", 1, "user");
+    insertMessage(db, "pending", "s1", 2, "assistant", { extracted: 0 });
+
+    const result = runMessageRetention(db, normalizeMessageRetentionPolicy(undefined));
+
+    expect(result.policy).toBe("all");
+    expect(result.selectedRows).toBe(0);
+    expect(result.deletedRows).toBe(0);
+    expect(ids(db)).toEqual(["extracted", "pending"]);
+    db.close();
+  });
+
+  it("deletes only extracted, unreferenced rows", () => {
+    const db = createTestDb();
+    insertMessage(db, "delete-me", "s1", 1, "user");
+    insertMessage(db, "pending", "s1", 2, "assistant", { extracted: 0 });
+    insertMessage(db, "referenced", "s1", 3, "assistant");
+    const nodeId = insertNode(db, { name: "retained-source" });
+    db.prepare(`
+      INSERT INTO gm_node_sources (node_id, session_id, message_id, turn_index)
+      VALUES (?, 's1', 'referenced', 3)
+    `).run(nodeId);
+
+    const result = runMessageRetention(
+      db,
+      normalizeMessageRetentionPolicy({ keep: "referenced", batchSize: 10 }),
+    );
+
+    expect(result.selectedRows).toBe(1);
+    expect(result.deletedRows).toBe(1);
+    expect(ids(db)).toEqual(["pending", "referenced"]);
+    expect(db.prepare("SELECT COUNT(*) AS count FROM gm_node_sources").get()).toEqual({ count: 1 });
+    db.close();
+  });
+
+  it("preserves complete event spans for the newest real user turns", () => {
+    const db = createTestDb();
+    for (const [turn, role] of [
+      [1, "user"],
+      [2, "assistant"],
+      [3, "tool"],
+      [4, "user"],
+      [5, "assistant"],
+      [6, "user"],
+      [7, "assistant"],
+    ] as Array<[number, string]>) {
+      insertMessage(db, `m${turn}`, "s1", turn, role);
+    }
+
+    const result = runMessageRetention(
+      db,
+      normalizeMessageRetentionPolicy({ keep: "recent", recentTurns: 2, batchSize: 20 }),
+    );
+
+    expect(result.deletedRows).toBe(3);
+    expect(ids(db)).toEqual(["m4", "m5", "m6", "m7"]);
+    db.close();
+  });
+
+  it("combines turn and age windows conservatively and retains malformed timestamps", () => {
+    const db = createTestDb();
+    const now = 2_000_000_000_000;
+    insertMessage(db, "old", "s1", 1, "user", { createdAt: now - 10 * 86_400_000 });
+    insertMessage(db, "recent-by-age", "s1", 2, "assistant", { createdAt: now - 1_000 });
+    insertMessage(db, "bad-time", "s1", 3, "assistant", { createdAt: 0 });
+    insertMessage(db, "new-user", "s1", 4, "user", { createdAt: now - 1_000 });
+    insertMessage(db, "new-answer", "s1", 5, "assistant", { createdAt: now - 1_000 });
+
+    const result = runMessageRetention(
+      db,
+      normalizeMessageRetentionPolicy({
+        keep: "recent",
+        recentTurns: 1,
+        retentionDays: 3,
+        batchSize: 20,
+      }),
+      now,
+    );
+
+    expect(result.deletedRows).toBe(1);
+    expect(ids(db)).toEqual(["bad-time", "new-answer", "new-user", "recent-by-age"]);
+    db.close();
+  });
+
+  it("supports bounded dry runs without deleting candidates", () => {
+    const db = createTestDb();
+    for (let index = 1; index <= 3; index += 1) {
+      insertMessage(db, `m${index}`, `s${index}`, index, index === 1 ? "user" : "tool");
+    }
+
+    const result = runMessageRetention(
+      db,
+      normalizeMessageRetentionPolicy({
+        keep: "referenced",
+        dryRun: true,
+        batchSize: 2,
+      }),
+    );
+
+    expect(result.dryRun).toBe(true);
+    expect(result.selectedRows).toBe(2);
+    expect(result.deletedRows).toBe(0);
+    expect(result.hasMore).toBe(true);
+    expect(result.selectedSessions).toBe(2);
+    expect(result.byRole).toEqual({ user: 1, tool: 1 });
+    expect(ids(db)).toEqual(["m1", "m2", "m3"]);
+    db.close();
+  });
+
+  it("rolls back the entire batch when deletion fails", () => {
+    const db = createTestDb();
+    insertMessage(db, "a", "s1", 1, "user");
+    insertMessage(db, "b", "s1", 2, "assistant");
+    db.exec(`
+      CREATE TRIGGER fail_retention_delete
+      BEFORE DELETE ON gm_messages
+      WHEN OLD.id='b'
+      BEGIN
+        SELECT RAISE(ABORT, 'simulated retention failure');
+      END;
+    `);
+
+    expect(() => runMessageRetention(
+      db,
+      normalizeMessageRetentionPolicy({ keep: "referenced", batchSize: 10 }),
+    )).toThrow(/simulated retention failure/);
+    expect(ids(db)).toEqual(["a", "b"]);
+    db.close();
+  });
+
+  it("rejects destructive or ambiguous invalid configuration before opening the DB", () => {
+    expect(() => normalizeMessageRetentionPolicy({ keep: "recent" })).toThrow(/requires/);
+    expect(() => normalizeMessageRetentionPolicy({ keep: "recent", recentTurns: -1 })).toThrow(/recentTurns/);
+    expect(() => normalizeMessageRetentionPolicy({ keep: "referenced", batchSize: 0 })).toThrow(/batchSize/);
+    expect(() => normalizeMessageRetentionPolicy({ keep: "invalid" as any })).toThrow(/must be all/);
+  });
+});

--- a/test/migration.test.ts
+++ b/test/migration.test.ts
@@ -55,6 +55,15 @@ describe("database migrations", () => {
         created_at INTEGER NOT NULL,
         updated_at INTEGER NOT NULL
       );
+      CREATE TABLE gm_messages (
+        id TEXT PRIMARY KEY,
+        session_id TEXT NOT NULL,
+        turn_index INTEGER NOT NULL,
+        role TEXT NOT NULL,
+        content TEXT NOT NULL,
+        extracted INTEGER NOT NULL DEFAULT 0,
+        created_at INTEGER NOT NULL
+      );
       INSERT INTO gm_nodes (id, community_id, status) VALUES
         ('n2', 'c1', 'active'),
         ('n1', 'c1', 'active');
@@ -76,10 +85,12 @@ describe("database migrations", () => {
     expect(row.member_signature).toMatch(/^[a-f0-9]{40}$/);
     expect(
       (upgraded.prepare("SELECT MAX(v) AS version FROM _migrations").get() as any).version,
-    ).toBe(9);
+    ).toBe(10);
     const sourceColumns = upgraded.prepare("PRAGMA table_info(gm_node_sources)").all() as Array<{ name: string }>;
     expect(sourceColumns.map((column) => column.name)).toEqual([
       "node_id", "session_id", "message_id", "turn_index",
     ]);
+    const messageIndexes = upgraded.prepare("PRAGMA index_list(gm_messages)").all() as Array<{ name: string }>;
+    expect(messageIndexes.some((index) => index.name === "ix_gm_msg_retention")).toBe(true);
   });
 });


### PR DESCRIPTION
Fixes #93

Thanks @wdz211 for the concrete database-growth report and @liyangbing for helping validate the retention requirements.

## What changed

- keep the default fully backward-compatible (`messageRetention.keep: all`)
- add opt-in `referenced` and `recent` policies
- prune only extracted messages with no `gm_node_sources` provenance reference
- preserve configurable recent real-user turns and/or age windows
- process bounded batches in one transaction and re-check safety predicates at DELETE time
- expose dry-run/real receipts through `gm_maintain`, `gm_status`, and `gm_stats`
- add a retention index, fail-closed config validation, and bilingual rollout docs
- keep `VACUUM` separate so maintenance never introduces a surprise blocking rewrite

## Validation

- `npm test`: 18 files, 139/139 tests passed
- `npm run build` and `npm run build:dsh` passed
- `npm run verify:package`: 77 packed files verified, no install-time scripts
- official DSH `0.1.1-rc.2`: tarball installed into a fresh `web` profile; bundle and composed retention config verified
- synthetic pressure test: 200,000 messages / 100 sessions, 500-row batch, dry-run 90 ms, delete 121 ms, `integrity_check=ok`, 0 foreign-key violations, referenced source preserved

The docs recommend backup + dry-run before enabling deletion. Existing installations do not delete anything unless the operator explicitly changes `keep` away from `all`.